### PR TITLE
fix(kubectl-trace): image build trigger should not stay in makeopts

### DIFF
--- a/hack/ci-build-image.sh
+++ b/hack/ci-build-image.sh
@@ -5,7 +5,7 @@ make=$(command -v make)
 
 makeopts=""
 if [[ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]]; then
-  makeopts="-e GIT_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH image/build"
+  makeopts="-e GIT_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
 fi
 
 $make $makeopts image/build

--- a/hack/ci-release-image.sh
+++ b/hack/ci-release-image.sh
@@ -9,7 +9,7 @@ docker=$(command -v docker)
 
 makeopts=""
 if [[ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]]; then
-  makeopts="-e GIT_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH image/build"
+  makeopts="-e GIT_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
 fi
 
 if [[ ! -z "$QUAY_TOKEN" ]]; then


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>