### PR TITLE
fix(kubectl-trace): image name configurable

### DIFF
--- a/Dockerfile.tracerunner
+++ b/Dockerfile.tracerunner
@@ -1,6 +1,7 @@
 ARG bpftracesha
+ARG imagenamebase
 
-FROM quay.io/fntlnz/kubectl-trace-bpftrace-base:${bpftracesha} as bpftrace
+FROM ${imagenamebase}:${bpftracesha} as bpftrace
 FROM golang:1.11.4-alpine3.8 as gobuilder
 
 RUN apk update

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,19 @@ GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 
-IMAGE_TRACERUNNER_BRANCH := quay.io/fntlnz/kubectl-trace-bpftrace:$(GIT_BRANCH_CLEAN)
-IMAGE_TRACERUNNER_COMMIT := quay.io/fntlnz/kubectl-trace-bpftrace:$(GIT_COMMIT)
-IMAGE_TRACERUNNER_LATEST := quay.io/fntlnz/kubectl-trace-bpftrace:latest
+IMAGE_NAME      ?= quay.io/fntlnz/kubectl-trace-bpftrace
+IMAGE_NAME_BASE ?= quay.io/fntlnz/kubectl-trace-bpftrace-base
+
+IMAGE_TRACERUNNER_BRANCH := $(IMAGE_NAME):$(GIT_BRANCH_CLEAN)
+IMAGE_TRACERUNNER_COMMIT := $(IMAGE_NAME):$(GIT_COMMIT)
+IMAGE_TRACERUNNER_LATEST := $(IMAGE_NAME):latest
 
 BPFTRACESHA ?= 2ae2a53f62622631a304def6c193680e603994e3
-IMAGE_BPFTRACE_BASE := quay.io/fntlnz/kubectl-trace-bpftrace-base:$(BPFTRACESHA)
+IMAGE_BPFTRACE_BASE := $(IMAGE_NAME_BASE):$(BPFTRACESHA)
 
 IMAGE_BUILD_FLAGS ?= "--no-cache"
 
-LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT}'
+LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/version.imageName=${IMAGE_NAME}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)
 
 kubectl_trace ?= _output/bin/kubectl-trace
@@ -38,7 +41,12 @@ clean:
 
 .PHONY: image/build
 image/build:
-	$(DOCKER) build --build-arg bpftracesha=$(BPFTRACESHA) $(IMAGE_BUILD_FLAGS) -t $(IMAGE_TRACERUNNER_BRANCH) -f Dockerfile.tracerunner .
+	$(DOCKER) build \
+		--build-arg bpftracesha=$(BPFTRACESHA) \
+		--build-arg imagenamebase=$(IMAGE_NAME_BASE) \
+		$(IMAGE_BUILD_FLAGS) \
+		-t $(IMAGE_TRACERUNNER_BRANCH) \
+		-f Dockerfile.tracerunner .
 	$(DOCKER) tag $(IMAGE_TRACERUNNER_BRANCH) $(IMAGE_TRACERUNNER_COMMIT)
 
 .PHONY: image/push

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,9 +8,15 @@ import (
 
 // Populated by makefile
 var gitCommit string
+var imageName string
 var buildTime string
 var versionFormat = "git commit: %s\nbuild date: %s"
-var imageNameTagFormat = "quay.io/fntlnz/kubectl-trace-bpftrace:%s"
+var imageNameTagFormat = "%s:%s"
+
+// ImageName returns the container image name defined in Makefile
+func ImageName() string {
+	return imageName
+}
 
 func GitCommit() string {
 	return gitCommit
@@ -19,9 +25,9 @@ func GitCommit() string {
 func ImageNameTag() string {
 	commit := GitCommit()
 	if len(commit) == 0 {
-		return fmt.Sprintf(imageNameTagFormat, "latest")
+		return fmt.Sprintf(imageNameTagFormat, ImageName(), "latest")
 	}
-	return fmt.Sprintf(imageNameTagFormat, GitCommit())
+	return fmt.Sprintf(imageNameTagFormat, ImageName(), GitCommit())
 }
 
 func Time() *time.Time {


### PR DESCRIPTION
I have been testing with the following:
```
export IMAGE_NAME=quay.io/alban/kubectl-trace-bpftrace
export IMAGE_NAME_BASE=quay.io/alban/kubectl-trace-bpftrace-base
```
