### PR TITLE
build: configure cross compile test builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _output/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,45 @@
+project_name: kubectl-trace
+builds:
+  - goos:
+    - linux
+    - darwin
+    - windows
+    goarch:
+    - amd64
+    - 386
+    main: ./cmd/kubectl-trace
+    env:
+      - GO111MODULE=on
+      - CGO_ENABLED=0
+    ldflags: |
+      -X github.com/iovisor/kubectl-trace/pkg/version.buildTime={{ .Timestamp }}
+      -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit={{ .Commit }}
+      -X github.com/iovisor/kubectl-trace/pkg/version.imageName={{ .Env.IMAGE_NAME }}
+    binary: kubectl-trace
+  - goos:
+    - linux
+    - darwin
+    - windows
+    goarch:
+    - amd64
+    - 386
+    main: ./cmd/trace-runner
+    env:
+      - GO111MODULE=on
+      - CGO_ENABLED=0
+    ldflags: |
+      -X github.com/iovisor/kubectl-trace/pkg/version.buildTime={{ .Timestamp }}
+      -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit={{ .Commit }}
+      -X github.com/iovisor/kubectl-trace/pkg/version.imageName={{ .Env.IMAGE_NAME }}
+    binary: trace-runner
+
+archive:
+  format_overrides:
+    - goos: windows
+      format: zip
+
+snapshot:
+  name_template: 'master'
+
+release:
+  disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 project_name: kubectl-trace
+before:
+  hooks:
+    - go mod tidy
 builds:
   - id: "kubectl-trace"
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 project_name: kubectl-trace
 builds:
-  - goos:
+  - id: "kubectl-trace"
+    goos:
     - linux
     - darwin
     - windows
@@ -16,7 +17,8 @@ builds:
       -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit={{ .Commit }}
       -X github.com/iovisor/kubectl-trace/pkg/version.imageName={{ .Env.IMAGE_NAME }}
     binary: kubectl-trace
-  - goos:
+  - id: "trace-runner"
+    goos:
     - linux
     - darwin
     - windows
@@ -33,13 +35,15 @@ builds:
       -X github.com/iovisor/kubectl-trace/pkg/version.imageName={{ .Env.IMAGE_NAME }}
     binary: trace-runner
 
-archive:
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  - id: windows
+    format_overrides:
+      - goos: windows
+        format: zip
 
 snapshot:
   name_template: 'master'
 
 release:
-  disable: true
+  github:
+  prerelease: auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ go:
 - 1.11.4
 services:
 - docker
+before_install:
+  - go get github.com/goreleaser/goreleaser
 script:
 - make test
 - make _output/bin/kubectl-trace
 - ./hack/ci-build-image.sh
 - make integration
+- make cross
 after_success:
 - ./hack/ci-release-image.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 services:
 - docker
 before_install:
-  - GO111MODULE=on; go get github.com/goreleaser/goreleaser
+- curl -LO https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_amd64.deb && sudo dpkg -i goreleaser_amd64.deb 
 script:
 - make test
 - make _output/bin/kubectl-trace
@@ -16,3 +16,11 @@ script:
 - make cross
 after_success:
 - ./hack/ci-release-image.sh
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: goreleaser
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 services:
 - docker
 before_install:
-  - go get github.com/goreleaser/goreleaser
+  - GO111MODULE=on; go get github.com/goreleaser/goreleaser
 script:
 - make test
 - make _output/bin/kubectl-trace

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ${trace_runner}:
 
 .PHONY: cross
 cross:
-	IMAGE_NAME=$(IMAGE_NAME) goreleaser --snapshot --rm-dist
+	IMAGE_NAME=$(IMAGE_NAME) GO111MODULE=on goreleaser --snapshot --rm-dist
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ${trace_runner}:
 
 .PHONY: cross
 cross:
-	IMAGE_NAME=$(IMAGE_NAME) go run github.com/goreleaser/goreleaser --snapshot --rm-dist
+	IMAGE_NAME=$(IMAGE_NAME) goreleaser --snapshot --rm-dist
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,14 @@ ${kubectl_trace}:
 ${trace_runner}:
 	CGO_ENABLED=1 $(GO) build ${LDFLAGS} -o $@ ./cmd/trace-runner
 
+.PHONY: cross
+cross:
+	IMAGE_NAME=$(IMAGE_NAME) go run github.com/goreleaser/goreleaser --snapshot --rm-dist
+
 .PHONY: clean
 clean:
-	rm -Rf _output
+	$(RM) -R _output
+	$(RM) -R dist
 
 .PHONY: image/build-init
 image/build-init:


### PR DESCRIPTION
This issue will setup goreleaser and cross compile kubectl-trace for multiple platforms. This would be a starting point for issue #9.