### PR TITLE
feat: Automatically fetch headers for Google's Container OS linux header install via initContainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ image/build:
 		-f Dockerfile.tracerunner .
 	$(DOCKER) tag $(IMAGE_TRACERUNNER_BRANCH) $(IMAGE_TRACERUNNER_COMMIT)
 
+.PHONY: image/build-init
+image/build-init:
+	$(DOCKER) build \
+		-f ./init/Dockerfile.initcontainer ./init
+
 .PHONY: image/push
 image/push:
 	$(DOCKER) push $(IMAGE_TRACERUNNER_BRANCH)

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ image/build:
 .PHONY: image/build-init
 image/build-init:
 	$(DOCKER) build \
+		$(IMAGE_BUILD_FLAGS) \
+		-t $(IMAGE_INITCONTAINER_BRANCH) \
 		-f ./init/Dockerfile.initcontainer ./init
+	$(DOCKER) tag $(IMAGE_INITCONTAINER_BRANCH) $(IMAGE_INITCONTAINER_COMMIT)
 
 .PHONY: image/push
 image/push:

--- a/init/Dockerfile.initcontainer
+++ b/init/Dockerfile.initcontainer
@@ -1,0 +1,15 @@
+FROM alpine:3.8
+RUN apk add --update \
+  bash \
+  bc \
+  build-base \
+  curl \
+  libelf-dev \
+  linux-headers \
+  make
+
+WORKDIR /
+
+COPY /fetch-linux-headers.sh /
+
+ENTRYPOINT [ "/fetch-linux-headers.sh" ]

--- a/init/fetch-linux-headers.sh
+++ b/init/fetch-linux-headers.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -x
+
+LSB_FILE="/etc/lsb-release.host"
+OS_RELEASE_FILE="/etc/os-release.host"
+TARGET_DIR="/usr/src"
+HOST_MODULES_DIR="/lib/modules.host"
+
+generate_headers()
+{
+  echo "Generating kernel headers"
+  cd ${BUILD_DIR}
+  zcat /proc/config.gz > .config
+  make ARCH=x86 oldconfig > /dev/null
+  make ARCH=x86 prepare > /dev/null
+}
+
+fetch_cos_linux_sources()
+{
+  echo "Fetching upstream kernel sources."
+  mkdir -p ${BUILD_DIR}
+  curl -s "https://storage.googleapis.com/cos-tools/${BUILD_ID}/kernel-src.tar.gz" | tar -xzf - -C ${BUILD_DIR}
+}
+
+install_cos_linux_headers()
+{
+  if grep -q CHROMEOS_RELEASE_VERSION ${LSB_FILE};then
+    BUILD_ID=$(grep CHROMEOS_RELEASE_VERSION ${LSB_FILE} | cut -d = -f 2)
+    BUILD_DIR="/linux-lakitu-${BUILD_ID}"
+    SOURCES_DIR="${TARGET_DIR}/linux-lakitu-${BUILD_ID}"
+
+    if [ ! -e "${SOURCES_DIR}/.installed" ];then
+      echo "Installing kernel headers for for COS build ${BUILD_ID}"
+      fetch_cos_linux_sources
+      generate_headers
+      mv ${BUILD_DIR} ${TARGET_DIR}
+      touch "${SOURCES_DIR}/.installed"
+    fi
+  fi
+}
+
+install_headers()
+{
+  distro=$(grep ^NAME ${OS_RELEASE_FILE} | cut -d = -f 2)
+
+  case $distro in
+    *"Container-Optimized OS"*)
+      install_cos_linux_headers
+      HEADERS_TARGET=${SOURCES_DIR}
+      ;;
+    *)
+      echo "WARNING: ${distro} is not a supported distro, cannot install headers, ensure they are installed to /lib/modules"
+  esac
+}
+
+check_headers()
+{
+  modules_path=$1
+  utsname=$(uname -r)
+  arch=$(uname -m)
+  kdir="${modules_path}/${utsname}"
+
+  [ "${arch}" == "x86_64" ] && arch="x86"
+
+  [ ! -e ${kdir} ] && return 1
+  [ ! -e "${kdir}/source" ] && [ ! -e "${kdir}/build" ] && return 1
+
+  header_dir=$([ -e "${kdir}/source" ] && echo "${kdir}/source" || echo "${kdir}/build")
+
+  [ ! -e "${header_dir}/include/linux/kconfig.h" ] && return 1
+  [ ! -e "${header_dir}/include/generated/uapi" ] && return 1
+  [ ! -e "${header_dir}/arch/${arch}/include/generated/uapi" ] && return 1
+
+  return 0
+}
+
+if [ ! -e /lib/modules/.installed ];then
+  if ! check_headers ${HOST_MODULES_DIR}; then
+    install_headers
+  else
+    HEADERS_TARGET=${HOST_MODULES_DIR}/source
+  fi
+
+  mkdir -p "/lib/modules/$(uname -r)"
+  ln -sf ${HEADERS_TARGET} "/lib/modules/$(uname -r)/source"
+  ln -sf ${HEADERS_TARGET} "/lib/modules/$(uname -r)/build"
+  touch /lib/modules/.installed
+  exit 0
+else
+  echo "Headers already installed"
+  exit 0
+fi

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -288,8 +288,18 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 					},
 					InitContainers: []apiv1.Container{
 						apiv1.Container{
-							Name:    "kubectl-trace-init",
-							Image:   version.InitImageNameTag(),
+							Name:  "kubectl-trace-init",
+							Image: version.InitImageNameTag(),
+							Resources: apiv1.ResourceRequirements{
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("100m"),
+									apiv1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Limits: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse("1"),
+									apiv1.ResourceMemory: resource.MustParse("1G"),
+								},
+							},
 							VolumeMounts: []apiv1.VolumeMount{
 								apiv1.VolumeMount{
 									Name:      "lsb-release",

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -238,7 +238,7 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							},
 						},
 						apiv1.Volume{
-							Name: "modules",
+							Name: "modules-host",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
 									Path: "/lib/modules",
@@ -250,6 +250,69 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
 									Path: "/sys",
+								},
+							},
+						},
+						apiv1.Volume{
+							Name: "lsb-release",
+							VolumeSource: apiv1.VolumeSource{
+								HostPath: &apiv1.HostPathVolumeSource{
+									Path: "/etc/lsb-release",
+								},
+							},
+						},
+						apiv1.Volume{
+							Name: "os-release",
+							VolumeSource: apiv1.VolumeSource{
+								HostPath: &apiv1.HostPathVolumeSource{
+									Path: "/etc/os-release",
+								},
+							},
+						},
+						apiv1.Volume{
+							Name: "modules-dir",
+							VolumeSource: apiv1.VolumeSource{
+								HostPath: &apiv1.HostPathVolumeSource{
+									Path: "/var/cache/linux-headers/modules_dir",
+								},
+							},
+						},
+						apiv1.Volume{
+							Name: "linux-headers-generated",
+							VolumeSource: apiv1.VolumeSource{
+								HostPath: &apiv1.HostPathVolumeSource{
+									Path: "/var/cache/linux-headers/generated",
+								},
+							},
+						},
+					},
+					InitContainers: []apiv1.Container{
+						apiv1.Container{
+							Name:    "kubectl-trace-init",
+							Image:   version.InitImageNameTag(),
+							VolumeMounts: []apiv1.VolumeMount{
+								apiv1.VolumeMount{
+									Name:      "lsb-release",
+									MountPath: "/etc/lsb-release.host",
+									ReadOnly:  true,
+								},
+								apiv1.VolumeMount{
+									Name:      "os-release",
+									MountPath: "/etc/os-release.host",
+									ReadOnly:  true,
+								},
+								apiv1.VolumeMount{
+									Name:      "modules-dir",
+									MountPath: "/lib/modules",
+								},
+								apiv1.VolumeMount{
+									Name:      "modules-host",
+									MountPath: "/lib/modules.host",
+									ReadOnly:  true,
+								},
+								apiv1.VolumeMount{
+									Name:      "linux-headers-generated",
+									MountPath: "/usr/src/",
 								},
 							},
 						},
@@ -278,13 +341,23 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 									ReadOnly:  true,
 								},
 								apiv1.VolumeMount{
-									Name:      "modules",
+									Name:      "sys",
+									MountPath: "/sys",
+									ReadOnly:  true,
+								},
+								apiv1.VolumeMount{
+									Name:      "modules-dir",
 									MountPath: "/lib/modules",
 									ReadOnly:  true,
 								},
 								apiv1.VolumeMount{
-									Name:      "sys",
-									MountPath: "/sys",
+									Name:      "modules-host",
+									MountPath: "/lib/modules.host",
+									ReadOnly:  true,
+								},
+								apiv1.VolumeMount{
+									Name:      "linux-headers-generated",
+									MountPath: "/usr/src/",
 									ReadOnly:  true,
 								},
 							},

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -253,79 +253,6 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 								},
 							},
 						},
-						apiv1.Volume{
-							Name: "lsb-release",
-							VolumeSource: apiv1.VolumeSource{
-								HostPath: &apiv1.HostPathVolumeSource{
-									Path: "/etc/lsb-release",
-								},
-							},
-						},
-						apiv1.Volume{
-							Name: "os-release",
-							VolumeSource: apiv1.VolumeSource{
-								HostPath: &apiv1.HostPathVolumeSource{
-									Path: "/etc/os-release",
-								},
-							},
-						},
-						apiv1.Volume{
-							Name: "modules-dir",
-							VolumeSource: apiv1.VolumeSource{
-								HostPath: &apiv1.HostPathVolumeSource{
-									Path: "/var/cache/linux-headers/modules_dir",
-								},
-							},
-						},
-						apiv1.Volume{
-							Name: "linux-headers-generated",
-							VolumeSource: apiv1.VolumeSource{
-								HostPath: &apiv1.HostPathVolumeSource{
-									Path: "/var/cache/linux-headers/generated",
-								},
-							},
-						},
-					},
-					InitContainers: []apiv1.Container{
-						apiv1.Container{
-							Name:  "kubectl-trace-init",
-							Image: version.InitImageNameTag(),
-							Resources: apiv1.ResourceRequirements{
-								Requests: apiv1.ResourceList{
-									apiv1.ResourceCPU:    resource.MustParse("100m"),
-									apiv1.ResourceMemory: resource.MustParse("100Mi"),
-								},
-								Limits: apiv1.ResourceList{
-									apiv1.ResourceCPU:    resource.MustParse("1"),
-									apiv1.ResourceMemory: resource.MustParse("1G"),
-								},
-							},
-							VolumeMounts: []apiv1.VolumeMount{
-								apiv1.VolumeMount{
-									Name:      "lsb-release",
-									MountPath: "/etc/lsb-release.host",
-									ReadOnly:  true,
-								},
-								apiv1.VolumeMount{
-									Name:      "os-release",
-									MountPath: "/etc/os-release.host",
-									ReadOnly:  true,
-								},
-								apiv1.VolumeMount{
-									Name:      "modules-dir",
-									MountPath: "/lib/modules",
-								},
-								apiv1.VolumeMount{
-									Name:      "modules-host",
-									MountPath: "/lib/modules.host",
-									ReadOnly:  true,
-								},
-								apiv1.VolumeMount{
-									Name:      "linux-headers-generated",
-									MountPath: "/usr/src/",
-								},
-							},
-						},
 					},
 					Containers: []apiv1.Container{
 						apiv1.Container{
@@ -353,21 +280,6 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 								apiv1.VolumeMount{
 									Name:      "sys",
 									MountPath: "/sys",
-									ReadOnly:  true,
-								},
-								apiv1.VolumeMount{
-									Name:      "modules-dir",
-									MountPath: "/lib/modules",
-									ReadOnly:  true,
-								},
-								apiv1.VolumeMount{
-									Name:      "modules-host",
-									MountPath: "/lib/modules.host",
-									ReadOnly:  true,
-								},
-								apiv1.VolumeMount{
-									Name:      "linux-headers-generated",
-									MountPath: "/usr/src/",
 									ReadOnly:  true,
 								},
 							},
@@ -399,6 +311,110 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 		},
 	}
 
+	if nj.FetchHeaders {
+		// If we aren't downloading headers, add the initContainer and set up mounts
+		job.Spec.Template.Spec.InitContainers = []apiv1.Container{
+			apiv1.Container{
+				Name:  "kubectl-trace-init",
+				Image: nj.InitImageNameTag,
+				Resources: apiv1.ResourceRequirements{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("100m"),
+						apiv1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("1G"),
+					},
+				},
+				VolumeMounts: []apiv1.VolumeMount{
+					apiv1.VolumeMount{
+						Name:      "lsb-release",
+						MountPath: "/etc/lsb-release.host",
+						ReadOnly:  true,
+					},
+					apiv1.VolumeMount{
+						Name:      "os-release",
+						MountPath: "/etc/os-release.host",
+						ReadOnly:  true,
+					},
+					apiv1.VolumeMount{
+						Name:      "modules-dir",
+						MountPath: "/lib/modules",
+					},
+					apiv1.VolumeMount{
+						Name:      "modules-host",
+						MountPath: "/lib/modules.host",
+						ReadOnly:  true,
+					},
+					apiv1.VolumeMount{
+						Name:      "linux-headers-generated",
+						MountPath: "/usr/src/",
+					},
+				},
+			},
+		}
+
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes,
+			apiv1.Volume{
+				Name: "lsb-release",
+				VolumeSource: apiv1.VolumeSource{
+					HostPath: &apiv1.HostPathVolumeSource{
+						Path: "/etc/lsb-release",
+					},
+				},
+			},
+			apiv1.Volume{
+				Name: "os-release",
+				VolumeSource: apiv1.VolumeSource{
+					HostPath: &apiv1.HostPathVolumeSource{
+						Path: "/etc/os-release",
+					},
+				},
+			},
+			apiv1.Volume{
+				Name: "modules-dir",
+				VolumeSource: apiv1.VolumeSource{
+					HostPath: &apiv1.HostPathVolumeSource{
+						Path: "/var/cache/linux-headers/modules_dir",
+					},
+				},
+			},
+			apiv1.Volume{
+				Name: "linux-headers-generated",
+				VolumeSource: apiv1.VolumeSource{
+					HostPath: &apiv1.HostPathVolumeSource{
+						Path: "/var/cache/linux-headers/generated",
+					},
+				},
+			})
+
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			apiv1.VolumeMount{
+				Name:      "modules-dir",
+				MountPath: "/lib/modules",
+				ReadOnly:  true,
+			},
+			apiv1.VolumeMount{
+				Name:      "modules-host",
+				MountPath: "/lib/modules.host",
+				ReadOnly:  true,
+			},
+			apiv1.VolumeMount{
+				Name:      "linux-headers-generated",
+				MountPath: "/usr/src/",
+				ReadOnly:  true,
+			})
+
+	} else {
+		// If we aren't downloading headers, unconditionally used the ones linked in /lib/modules
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			apiv1.VolumeMount{
+				Name:      "modules-host",
+				MountPath: "/lib/modules",
+				ReadOnly:  true,
+			})
+	}
 	if _, err := t.ConfigClient.Create(cm); err != nil {
 		return nil, err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,6 +38,7 @@ func ImageNameTag() string {
 	return fmt.Sprintf(imageNameTagFormat, imageName, tag)
 }
 
+// InitImageNameTag returns the full image path and tag for the initContainer
 func InitImageNameTag() string {
 	return fmt.Sprintf(imageNameTagFormat, defaultInitImageName, defaultInitImageTag)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,37 +10,10 @@ import (
 var gitCommit string
 var buildTime string
 var versionFormat = "git commit: %s\nbuild date: %s"
-var imageNameTagFormat = "%s:%s"
-var defaultImageName = "quay.io/fntlnz/kubectl-trace-bpftrace"
-var defaultImageTag = "latest"
-var defaultInitImageName = "quay.io/dalehamel/kubectl-trace-init"
-var defaultInitImageTag = "latest"
-
-// ImageName returns the container image name defined in Makefile
-func ImageName() string {
-	return imageName
-}
 
 // GitCommit returns the git commit
 func GitCommit() string {
 	return gitCommit
-}
-
-func ImageNameTag() string {
-	imageName := ImageName()
-	tag := GitCommit()
-	if len(tag) == 0 {
-		tag = defaultImageTag
-	}
-	if len(imageName) == 0 {
-		imageName = defaultImageName
-	}
-	return fmt.Sprintf(imageNameTagFormat, imageName, tag)
-}
-
-// InitImageNameTag returns the full image path and tag for the initContainer
-func InitImageNameTag() string {
-	return fmt.Sprintf(imageNameTagFormat, defaultInitImageName, defaultInitImageTag)
 }
 
 // Time returns the build time

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,10 +10,36 @@ import (
 var gitCommit string
 var buildTime string
 var versionFormat = "git commit: %s\nbuild date: %s"
+var imageNameTagFormat = "%s:%s"
+var defaultImageName = "quay.io/fntlnz/kubectl-trace-bpftrace"
+var defaultImageTag = "latest"
+var defaultInitImageName = "quay.io/dalehamel/kubectl-trace-init"
+var defaultInitImageTag = "latest"
+
+// ImageName returns the container image name defined in Makefile
+func ImageName() string {
+	return imageName
+}
 
 // GitCommit returns the git commit
 func GitCommit() string {
 	return gitCommit
+}
+
+func ImageNameTag() string {
+	imageName := ImageName()
+	tag := GitCommit()
+	if len(tag) == 0 {
+		tag = defaultImageTag
+	}
+	if len(imageName) == 0 {
+		imageName = defaultImageName
+	}
+	return fmt.Sprintf(imageNameTagFormat, imageName, tag)
+}
+
+func InitImageNameTag() string {
+	return fmt.Sprintf(imageNameTagFormat, defaultInitImageName, defaultInitImageTag)
 }
 
 // Time returns the build time


### PR DESCRIPTION
This should be reasonably ready for review, and should fix #47 

As of now, the current status is:
* This works! I can run a test script on container OS now.
* It appears to be able to successfully download and generate headers to a shared location, and this is reasonably fast, subsequent loads don't have any noticeable overhead from the initContainer as I had hoped
 * When headers are already installed, the initContainer exists almost immediately and the tracer can start
* Headers will be read unconditionally from a cached path at `/var/cache/linux-headers`, which should dependably be writeable (see https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s05.html). Since we are literally just caching the headers, this should be fine
 * For hosts where headers are already installed, this will symlink to those.
 * For hosts missing headers, they will be downloaded here and the symlink will point to that instead.

This may actually make #7 not needed / "fix" #7, as the approach can just be to ensure that headers are always pointed to by this symlink.

Work still to do:
* [x] ~Modify tracer container to use custom header path if specified~ I went with a different approach
* [x] Verify that this works end-to-end
* [x] Cleanups in preparation for merge.

I would like if someone else could test this against another environment where headers are already present, to ensure that it uses the headers at /lib/modules.host, as I haven't tested this codepath. Just running a trace should be sufficient to prove that this works, but examining the symlinks in `/var/cache/linux-headers/modules_dir` would show this conclusively. My main concern is that this fixes my use-case, and breaks for other users.

If there are hosts where `/var/cache` is *not* writeable (which would frankly baffle me), then this will break kubectl-trace for those users.

@fntlnz can you give this a review, and help me out by QA'ing against any environments you think might make sense? I would hate to have this be merged and break kubectl trace for other users in a way I hadn't anticipated :)