### PR TITLE
fix: Specify resource requests and limits for trace job

### DIFF
--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -13,6 +13,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/api/resource"
 	batchv1typed "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
 )
@@ -255,6 +256,16 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							Command: bpfTraceCmd,
 							TTY:     true,
 							Stdin:   true,
+							Resources: apiv1.ResourceRequirements{
+							        Requests: apiv1.ResourceList{
+							                apiv1.ResourceCPU:    resource.MustParse("100m"),
+							                apiv1.ResourceMemory: resource.MustParse("100Mi"),
+							        },
+							        Limits: apiv1.ResourceList{
+							                apiv1.ResourceCPU:    resource.MustParse("1"),
+							                apiv1.ResourceMemory: resource.MustParse("1G"),
+							        },
+							},
 							VolumeMounts: []apiv1.VolumeMount{
 								apiv1.VolumeMount{
 									Name:      "program",


### PR DESCRIPTION
Fixes #49 

This sets the trace job to be burstable, with a very low CPU requirement (1/10th of a CPU), to ensure that the job can be easily scheduled without being disruptive. It sets a maximum of 1 full CPU as well.

Similarly, for memory it requires 100mb, with a maximum of 1Gb.

We can tune these up or down as need be, but for now this should be a wide range to operate in.

If #47 is merged, then requests/limits should be applied to the initContainer as well.

@fntlnz what do you think?