### PR TITLE
Images and headers flags for run command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 IMAGE_NAME      ?= quay.io/fntlnz/kubectl-trace-bpftrace
 IMAGE_NAME_BASE ?= quay.io/fntlnz/kubectl-trace-bpftrace-base
 
-IMAGE_NAME_INIT ?= quay.io/dalehamel/kubectl-trace-init
+IMAGE_NAME_INIT ?= quay.io/fntlnz/kubectl-trace-init
 
 IMAGE_TRACERUNNER_BRANCH := $(IMAGE_NAME):$(GIT_BRANCH_CLEAN)
 IMAGE_TRACERUNNER_COMMIT := $(IMAGE_NAME):$(GIT_COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ IMAGE_BPFTRACE_BASE := $(IMAGE_NAME_BASE):$(BPFTRACESHA)
 
 IMAGE_BUILD_FLAGS ?= "--no-cache"
 
-LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.imageNameTag=${IMAGE_TRACERUNNER_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.initImageNameTag=${IMAGE_INITCONTAINER_COMMIT}'
+LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageNameTag=${IMAGE_TRACERUNNER_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageNameTag=${IMAGE_INITCONTAINER_COMMIT}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)
 
 kubectl_trace ?= _output/bin/kubectl-trace
@@ -71,7 +71,7 @@ test:
 
 .PHONY: integration
 integration:
-	TEST_KUBECTLTRACE_BINARY=$(shell pwd)/$(kubectl_trace) $(GO)  test ${LDFLAGS} -v ./integration/...
+	TEST_KUBECTLTRACE_BINARY=$(shell pwd)/$(kubectl_trace) $(GO) test ${LDFLAGS} -v ./integration/...
 
 .PHONY: bpftraceimage/build
 bpftraceimage/build:

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,22 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 IMAGE_NAME      ?= quay.io/fntlnz/kubectl-trace-bpftrace
 IMAGE_NAME_BASE ?= quay.io/fntlnz/kubectl-trace-bpftrace-base
 
+IMAGE_NAME_INIT ?= quay.io/dalehamel/kubectl-trace-init
+
 IMAGE_TRACERUNNER_BRANCH := $(IMAGE_NAME):$(GIT_BRANCH_CLEAN)
 IMAGE_TRACERUNNER_COMMIT := $(IMAGE_NAME):$(GIT_COMMIT)
 IMAGE_TRACERUNNER_LATEST := $(IMAGE_NAME):latest
+
+IMAGE_INITCONTAINER_BRANCH := $(IMAGE_NAME_INIT):$(GIT_BRANCH_CLEAN)
+IMAGE_INITCONTAINER_COMMIT := $(IMAGE_NAME_INIT):$(GIT_COMMIT)
+IMAGE_INITCONTAINER_LATEST := $(IMAGE_NAME_INIT):latest
 
 BPFTRACESHA ?= 2ae2a53f62622631a304def6c193680e603994e3
 IMAGE_BPFTRACE_BASE := $(IMAGE_NAME_BASE):$(BPFTRACESHA)
 
 IMAGE_BUILD_FLAGS ?= "--no-cache"
 
-LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/version.imageName=${IMAGE_NAME}'
+LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.imageNameTag=${IMAGE_TRACERUNNER_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.initImageNameTag=${IMAGE_INITCONTAINER_COMMIT}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)
 
 kubectl_trace ?= _output/bin/kubectl-trace

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-check/check"
-	"github.com/iovisor/kubectl-trace/pkg/version"
+	"github.com/iovisor/kubectl-trace/pkg/cmd"
 	"gotest.tools/icmd"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/config/encoding"
@@ -59,7 +59,7 @@ func (k *KubectlTraceSuite) SetUpSuite(c *check.C) {
 
 	// copy the bpftrace image to the nodes
 	for _, n := range nodes {
-		loadcomm := fmt.Sprintf("docker save %s | docker exec -i %s docker load", version.ImageNameTag(), n.String())
+		loadcomm := fmt.Sprintf("docker save %s | docker exec -i %s docker load", cmd.ImageNameTag, n.String())
 		res := icmd.RunCommand("bash", "-c", loadcomm)
 		c.Assert(res.Error, check.IsNil)
 	}

--- a/pkg/cmd/attach.go
+++ b/pkg/cmd/attach.go
@@ -92,6 +92,7 @@ func (o *AttachOptions) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// Complete completes the setup of the command.
 func (o *AttachOptions) Complete(factory factory.Factory, cmd *cobra.Command, args []string) error {
 	// Prepare namespace
 	var err error

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -102,6 +102,7 @@ func (o *DeleteOptions) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// Complete completes the setup of the command.
 func (o *DeleteOptions) Complete(factory factory.Factory, cmd *cobra.Command, args []string) error {
 	// Prepare namespace
 	var err error

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -111,6 +111,7 @@ func (o *GetOptions) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// Complete completes the setup of the command.
 func (o *GetOptions) Complete(factory factory.Factory, cmd *cobra.Command, args []string) error {
 	// Prepare namespace
 	var err error
@@ -125,7 +126,7 @@ func (o *GetOptions) Complete(factory factory.Factory, cmd *cobra.Command, args 
 		o.namespace = ""
 	}
 
-	//// Prepare client
+	// Prepare client
 	o.clientConfig, err = factory.ToRESTConfig()
 	if err != nil {
 		return err

--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -85,6 +85,7 @@ func NewLogCommand(factory factory.Factory, streams genericclioptions.IOStreams)
 	return cmd
 }
 
+// Validate validates the arguments and flags populating LogOptions accordingly.
 func (o *LogOptions) Validate(cmd *cobra.Command, args []string) error {
 	if meta.IsObjectName(args[0]) {
 		o.traceName = &args[0]
@@ -96,6 +97,7 @@ func (o *LogOptions) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// Complete completes the setup of the command.
 func (o *LogOptions) Complete(factory factory.Factory, cmd *cobra.Command, args []string) error {
 	// Prepare namespace
 	var err error

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	imageNameTag     = "quay.io/fntlnz/kubectl-trace-bpftrace:latest"
-	initImageNameTag = "quay.io/dalehamel/kubectl-trace-init"
+	// ImageNameTag represents the default tracerunner image
+	ImageNameTag = "quay.io/fntlnz/kubectl-trace-bpftrace:latest"
+	// InitImageNameTag represents the default init container image
+	InitImageNameTag = "quay.io/dalehamel/kubectl-trace-init:latest"
 )
 
 var (
@@ -85,8 +87,8 @@ func NewRunOptions(streams genericclioptions.IOStreams) *RunOptions {
 		IOStreams: streams,
 
 		serviceAccount: "default",
-		imageName:      imageNameTag,
-		initImageName:  initImageNameTag,
+		imageName:      ImageNameTag,
+		initImageName:  InitImageNameTag,
 	}
 }
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -120,13 +120,13 @@ func NewRunCommand(factory factory.Factory, streams genericclioptions.IOStreams)
 	}
 
 	cmd.Flags().StringVarP(&o.container, "container", "c", o.container, "Specify the container")
-	cmd.Flags().BoolVarP(&o.attach, "attach", "a", o.attach, "Wheter or not to attach to the trace program once it is created")
+	cmd.Flags().BoolVarP(&o.attach, "attach", "a", o.attach, "Whether or not to attach to the trace program once it is created")
 	cmd.Flags().StringVarP(&o.eval, "eval", "e", o.eval, "Literal string to be evaluated as a bpftrace program")
 	cmd.Flags().StringVarP(&o.program, "filename", "f", o.program, "File containing a bpftrace program")
 	cmd.Flags().StringVar(&o.serviceAccount, "serviceaccount", o.serviceAccount, "Service account to use to set in the pod spec of the kubectl-trace job")
 	cmd.Flags().StringVar(&o.imageName, "imagename", o.imageName, "Custom image for the tracerunner")
 	cmd.Flags().StringVar(&o.initImageName, "init-imagename", o.initImageName, "Custom image for the init container responsible to fetch and prepare linux headers")
-	cmd.Flags().BoolVar(&o.fetchHeaders, "fetch-headers", o.fetchHeaders, "Wheter to fetch linux headers or not")
+	cmd.Flags().BoolVar(&o.fetchHeaders, "fetch-headers", o.fetchHeaders, "Whether to fetch linux headers or not")
 
 	return cmd
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -53,17 +53,17 @@ type RunOptions struct {
 	namespace         string
 	explicitNamespace bool
 
-	// Local to this command
+	// Flags local to this command
 	container      string
 	eval           string
 	program        string
-	resourceArg    string
-	attach         bool
-	isPod          bool
-	podUID         string
 	serviceAccount string
 
-	nodeName string
+	resourceArg string
+	attach      bool
+	isPod       bool
+	podUID      string
+	nodeName    string
 
 	clientConfig *rest.Config
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -24,7 +24,7 @@ var (
 	// ImageNameTag represents the default tracerunner image
 	ImageNameTag = "quay.io/fntlnz/kubectl-trace-bpftrace:latest"
 	// InitImageNameTag represents the default init container image
-	InitImageNameTag = "quay.io/dalehamel/kubectl-trace-init:latest"
+	InitImageNameTag = "quay.io/fntlnz/kubectl-trace-init:latest"
 )
 
 var (

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -42,10 +42,12 @@ var (
   # Run an bpftrace inline program on a pod container
   %[1]s trace run pod/nginx -c nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
   %[1]s trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
-  %[1]s trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
 
   # Run a bpftrace inline program on a pod container with a custom image for the init container responsible to fetch linux headers 
-  %[1]s trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --init-imagename=quay.io/custom-init-image-name --fetch-headers"`
+  %[1]s trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --init-imagename=quay.io/custom-init-image-name --fetch-headers"
+
+  # Run a bpftrace inline program on a pod container with a custom image for the bpftrace container that will run your program in the cluster
+  %[1]s trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --imagename=quay.io/custom-bpftrace-image-name"`
 
 	runCommand                    = "run"
 	usageString                   = "(POD | TYPE/NAME)"

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -34,7 +34,7 @@ var (
 
 	runExamples = `
   # Count system calls using tracepoints on a specific node
-  %[1]s trace run node/kubernetes-node-emt8.c.myproject.internal -e 'kprobe:do_sys_open { printf("%s: %s\n", comm, str(arg1)) }'
+  %[1]s trace run node/kubernetes-node-emt8.c.myproject.internal -e 'kprobe:do_sys_open { printf("%%s: %%s\n", comm, str(arg1)) }'
 
   # Execute a bpftrace program from file on a specific node
   %[1]s trace run node/kubernetes-node-emt8.c.myproject.internal -f read.bt

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const (
+var (
 	// ImageNameTag represents the default tracerunner image
 	ImageNameTag = "quay.io/fntlnz/kubectl-trace-bpftrace:latest"
 	// InitImageNameTag represents the default init container image

--- a/pkg/cmd/trace.go
+++ b/pkg/cmd/trace.go
@@ -76,5 +76,18 @@ func NewTraceCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(NewVersionCommand(streams))
 	cmd.AddCommand(NewLogCommand(f, streams))
 
+	// Override help on all the commands tree
+	walk(cmd, func(c *cobra.Command) {
+		c.Flags().BoolP("help", "h", false, fmt.Sprintf("Help for the %s command", c.Name()))
+	})
+
 	return cmd
+}
+
+// walk calls f for c and all of its children.
+func walk(c *cobra.Command, f func(*cobra.Command)) {
+	f(c)
+	for _, c := range c.Commands() {
+		walk(c, f)
+	}
 }

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -50,7 +50,7 @@ func NewTraceRunnerCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&o.podUID, "poduid", "p", o.podUID, "Specify the pod UID")
 	cmd.Flags().StringVarP(&o.programPath, "program", "f", "program.bt", "Specify the bpftrace program path")
 	cmd.Flags().StringVarP(&o.bpftraceBinaryPath, "bpftracebinary", "b", "/bin/bpftrace", "Specify the bpftrace binary path")
-	cmd.Flags().BoolVar(&o.inPod, "inpod", false, "Wheter or not run this bpftrace in a pod's container process namespace")
+	cmd.Flags().BoolVar(&o.inPod, "inpod", false, "Whether or not run this bpftrace in a pod's container process namespace")
 	return cmd
 }
 

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -50,7 +50,7 @@ func NewTraceRunnerCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&o.podUID, "poduid", "p", o.podUID, "Specify the pod UID")
 	cmd.Flags().StringVarP(&o.programPath, "program", "f", "program.bt", "Specify the bpftrace program path")
 	cmd.Flags().StringVarP(&o.bpftraceBinaryPath, "bpftracebinary", "b", "/bin/bpftrace", "Specify the bpftrace binary path")
-	cmd.Flags().BoolVar(&o.inPod, "inpod", false, "Wether or not run this bpftrace in a pod's container process namespace")
+	cmd.Flags().BoolVar(&o.inPod, "inpod", false, "Wheter or not run this bpftrace in a pod's container process namespace")
 	return cmd
 }
 
@@ -62,6 +62,7 @@ func (o *TraceRunnerOptions) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// Complete completes the setup of the command.
 func (o *TraceRunnerOptions) Complete(cmd *cobra.Command, args []string) error {
 	return nil
 }

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+// NewVersionCommand provides the version command.
 func NewVersionCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,34 +8,15 @@ import (
 
 // Populated by makefile
 var gitCommit string
-var imageName string
 var buildTime string
 var versionFormat = "git commit: %s\nbuild date: %s"
-var imageNameTagFormat = "%s:%s"
-var defaultImageName = "quay.io/fntlnz/kubectl-trace-bpftrace"
-var defaultImageTag = "latest"
 
-// ImageName returns the container image name defined in Makefile
-func ImageName() string {
-	return imageName
-}
-
+// GitCommit returns the git commit
 func GitCommit() string {
 	return gitCommit
 }
 
-func ImageNameTag() string {
-	imageName := ImageName()
-	tag := GitCommit()
-	if len(tag) == 0 {
-		tag = defaultImageTag
-	}
-	if len(imageName) == 0 {
-		imageName = defaultImageName
-	}
-	return fmt.Sprintf(imageNameTagFormat, imageName, tag)
-}
-
+// Time returns the build time
 func Time() *time.Time {
 	if len(buildTime) == 0 {
 		return nil
@@ -48,6 +29,7 @@ func Time() *time.Time {
 	return &t
 }
 
+// String returns version info as a string
 func String() string {
 	ts := Time()
 	if ts == nil {


### PR DESCRIPTION
Closes #53 

Regards #48 too (probably needs to be rebased on top of this or the master if this will be merged, to continue to work on).

This PR introduces the following flags for the run command and behavior:

- `--imagename` (defaulting to "quay.io/fntlnz/kubectl-trace-bpftrace:latest")
- `--init-imagename` (defaulting to "quay.io/dalehamel/kubectl-trace-init")
- `--fetch-headers` (defaulting to false)

Notice that defaults will be changed when we'll have "official" default images.

Furthermore this PR removes from version command the info about the tracerunner image in use since it is not related to the version of kubectl-trace imho.