### PR TITLE
fix: Accept completed job for log command

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -47,7 +47,7 @@ func (l *Logs) Run(jobID types.UID, namespace string, follow bool, timestamps bo
 	}
 
 	pod := &pl.Items[0]
-	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+	if pod.Status.Phase == corev1.PodFailed {
 		return fmt.Errorf(podPhaseNotAcceptedError, pod.Status.Phase)
 	}
 


### PR DESCRIPTION
Small change to accept pod in `Succeeded` phase.
Attempt to fix #61 

### The trace pod is completed
```shell
$ kubectl get pod kubectl-trace-43db844d-3ae6-11e9-8802-9cb6d0de1923-bkrwj 
NAME                                                       READY   STATUS      RESTARTS   AGE
kubectl-trace-43db844d-3ae6-11e9-8802-9cb6d0de1923-bkrwj   0/1     Completed   0          12m
```

### Let's try to view the output 
```shell
$ kubectl trace log 43db844d-3ae6-11e9-8802-9cb6d0de1923
kubelet: /sys/fs/cgroup/blkio/kubepods/blkio.throttle.io_serviced
kubelet: /sys/fs/cgroup/memory/kubepods/memory.stat
redis-server: /proc/1/stat
^C
first SIGINT received, now if your program had maps and did not free them it should print them out
```
The output is displayed. 🙂