### PR TITLE
feat: Implement missing fields in Get

### DIFF
--- a/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duration
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShortHumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans.
+func ShortHumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*365 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}
+
+// HumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans. It provides ~2-3 significant
+// figures of duration.
+func HumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60*2 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := int(d / time.Minute)
+	if minutes < 10 {
+		s := int(d/time.Second) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", minutes)
+		}
+		return fmt.Sprintf("%dm%ds", minutes, s)
+	} else if minutes < 60*3 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := int(d / time.Hour)
+	if hours < 8 {
+		m := int(d/time.Minute) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", hours)
+		}
+		return fmt.Sprintf("%dh%dm", hours, m)
+	} else if hours < 48 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*8 {
+		h := hours % 24
+		if h == 0 {
+			return fmt.Sprintf("%dd", hours/24)
+		}
+		return fmt.Sprintf("%dd%dh", hours/24, h)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%dd", hours/24)
+	} else if hours < 24*365*8 {
+		return fmt.Sprintf("%dy%dd", hours/24/365, (hours/24)%365)
+	}
+	return fmt.Sprintf("%dy", int(hours/24/365))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -246,6 +246,7 @@ k8s.io/api/storage/v1beta1
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/wait
+k8s.io/apimachinery/pkg/util/duration
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/runtime/schema


### PR DESCRIPTION
Add `Status` and `age` fields in the table printed out on a `kubectl trace get`

Attempt to fix #34
[![](https://user-images.githubusercontent.com/273896/53654156-078d6000-3c1b-11e9-86e1-4cee970d1f19.png)](https://github.com/iovisor/kubectl-trace/labels/good%20first%20issue)

### Example of use:
```shell
$ kubectl trace get
NAMESPACE	NODE		NAME							STATUS		AGE	
default		kind-worker2	kubectl-trace-f2db30bc-3c3e-11e9-a337-9cb6d0de1923	Running		27s	
default		kind-worker1	kubectl-trace-f4dbd43e-3c3e-11e9-8c3c-9cb6d0de1923	Completed	24s	
```
Here we have two traces, one running and the other completed.


We can also add other fields such as `duration` but I am not sure that it is very useful.