### PR TITLE
chore(bpftracebase): bump bpftrace base to 81b099f094d2e6092cfe1317cbaaba0c1bbb614f and bcc 0.8.0

### DIFF
--- a/Dockerfile.bpftracebase
+++ b/Dockerfile.bpftracebase
@@ -1,5 +1,6 @@
 FROM alpine:3.8 as builder
 ARG bpftracesha
+ARG bccversion
 ENV STATIC_LINKING=ON
 ENV RUN_TESTS=0
 RUN apk add --update \
@@ -7,6 +8,7 @@ RUN apk add --update \
   build-base \
   clang-dev \
   clang-static \
+  curl \
   cmake \
   elfutils-dev \
   flex-dev \
@@ -14,6 +16,7 @@ RUN apk add --update \
   linux-headers \
   llvm5-dev \
   llvm5-static \
+  python \
   zlib-dev
 
 # Put LLVM directories where CMake expects them to be
@@ -22,6 +25,14 @@ RUN ln -s /usr/include/llvm5/llvm /usr/include/llvm
 RUN ln -s /usr/include/llvm5/llvm-c /usr/include/llvm-c
 
 WORKDIR /
+RUN curl -L https://github.com/iovisor/bcc/archive/v${bccversion}.tar.gz \
+  --output /bcc.tar.gz
+RUN tar xvf /bcc.tar.gz
+RUN mv bcc-${bccversion} bcc
+RUN cd /bcc && mkdir build && cd build && cmake .. && make install -j4 && \
+  cp src/cc/libbcc.a /usr/local/lib64/libbcc.a && \
+  cp src/cc/libbcc-loader-static.a /usr/local/lib64/libbcc-loader-static.a && \
+  cp src/cc/libbpf.a /usr/local/lib64/libbpf.a
 
 ADD https://github.com/iovisor/bpftrace/archive/${bpftracesha}.tar.gz /bpftrace.tar.gz
 RUN tar -xvf /bpftrace.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ IMAGE_INITCONTAINER_BRANCH := $(IMAGE_NAME_INIT):$(GIT_BRANCH_CLEAN)
 IMAGE_INITCONTAINER_COMMIT := $(IMAGE_NAME_INIT):$(GIT_COMMIT)
 IMAGE_INITCONTAINER_LATEST := $(IMAGE_NAME_INIT):latest
 
-BPFTRACESHA ?= 2ae2a53f62622631a304def6c193680e603994e3
+BPFTRACESHA ?= 81b099f094d2e6092cfe1317cbaaba0c1bbb614f
+BCCVERSION ?= 0.8.0
 IMAGE_BPFTRACE_BASE := $(IMAGE_NAME_BASE):$(BPFTRACESHA)
 
 IMAGE_BUILD_FLAGS ?= "--no-cache"
@@ -75,7 +76,7 @@ integration:
 
 .PHONY: bpftraceimage/build
 bpftraceimage/build:
-	$(DOCKER) build --build-arg bpftracesha=$(BPFTRACESHA) $(IMAGE_BUILD_FLAGS) -t $(IMAGE_BPFTRACE_BASE) -f Dockerfile.bpftracebase .
+	$(DOCKER) build --build-arg bccversion=$(BCCVERSION) --build-arg bpftracesha=$(BPFTRACESHA) $(IMAGE_BUILD_FLAGS) -t $(IMAGE_BPFTRACE_BASE) -f Dockerfile.bpftracebase .
 
 .PHONY: bpftraceimage/push
 bpftraceimage/push:


### PR DESCRIPTION
- Updated bpftrace to 81b099f094d2e6092cfe1317cbaaba0c1bbb614f
- Updated bcc to 0.8.0
Signed-off-by: Lorenzo Fontana <lo@linux.com>