### PR TITLE
fix: Don't build bpftrace tests

### DIFF
--- a/Dockerfile.bpftracebase
+++ b/Dockerfile.bpftracebase
@@ -43,4 +43,4 @@ WORKDIR /bpftrace
 
 WORKDIR /bpftrace/docker
 
-RUN sh build.sh /bpftrace/build-release Release
+RUN sh build.sh /bpftrace/build-release Release bpftrace


### PR DESCRIPTION
My original branch depended on an upstream change in bpftrace, but it's not needed. Providing `bpftrace` as a build target is enough.

Resolves #43.