### PR TITLE
fix: Mount /usr/src in pod template

### DIFF
--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -238,6 +238,14 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							},
 						},
 						apiv1.Volume{
+							Name: "usr-src-host",
+							VolumeSource: apiv1.VolumeSource{
+								HostPath: &apiv1.HostPathVolumeSource{
+									Path: "/usr/src",
+								},
+							},
+						},
+						apiv1.Volume{
 							Name: "modules-host",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
@@ -409,6 +417,11 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 	} else {
 		// If we aren't downloading headers, unconditionally used the ones linked in /lib/modules
 		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts,
+			apiv1.VolumeMount{
+				Name:      "usr-src-host",
+				MountPath: "/usr/src",
+				ReadOnly:  true,
+			},
 			apiv1.VolumeMount{
 				Name:      "modules-host",
 				MountPath: "/lib/modules",


### PR DESCRIPTION
Ensure that /usr/src is mounted, since several common distributions link
`/lib/modules/$(uname -r)/build` to `/usr/src/kernels/$(uname -r)` or
`/usr/src/linux-headers-$(uname -r)`.

This was required for me to successfully locate kernel headers on Amazon Linux 2.

Fixes: #76 