### PR TITLE
feat: Job deadlines

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -28,7 +28,8 @@ var (
 	// DefaultDeadline is the maximum time a tracejob is allowed to run, in seconds
 	DefaultDeadline = 3600
 	// DefaultDeadlineGracePeriod is the maximum time to wait to print a map or histogram, in seconds
-	DefaultDeadlineGracePeriod = 10
+	// note that it must account for startup time, as the deadline as based on start time
+	DefaultDeadlineGracePeriod = 30
 )
 
 var (
@@ -136,7 +137,7 @@ func NewRunCommand(factory factory.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().StringVar(&o.initImageName, "init-imagename", o.initImageName, "Custom image for the init container responsible to fetch and prepare linux headers")
 	cmd.Flags().BoolVar(&o.fetchHeaders, "fetch-headers", o.fetchHeaders, "Whether to fetch linux headers or not")
 	cmd.Flags().Int64Var(&o.deadline, "deadline", o.deadline, "Maximum time to allow trace to run in seconds")
-	cmd.Flags().Int64Var(&o.deadline, "deadline-grace-period", o.deadlineGracePeriod, "Maximum wait time to print maps or histograms after deadline, in seconds")
+	cmd.Flags().Int64Var(&o.deadlineGracePeriod, "deadline-grace-period", o.deadlineGracePeriod, "Maximum wait time to print maps or histograms after deadline, in seconds")
 
 	return cmd
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -25,7 +25,7 @@ var (
 	ImageNameTag = "quay.io/iovisor/kubectl-trace-bpftrace:latest"
 	// InitImageNameTag represents the default init container image
 	InitImageNameTag = "quay.io/iovisor/kubectl-trace-init:latest"
-	// By default do not allow traces to run for longer than one hour
+	// DefaultDeadline default do not allow traces to run for longer than one hour
 	DefaultDeadline = 3600
 )
 

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -312,7 +312,7 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 										Command: []string{
 											"/bin/bash",
 											"-c",
-											fmt.Sprintf("kill -SIGINT $(pidof bpftrace) && sleep %i", strconv.FormatInt(nj.DeadlineGracePeriod, 10)),
+											fmt.Sprintf("kill -SIGINT $(pidof bpftrace) && sleep %s", strconv.FormatInt(nj.DeadlineGracePeriod, 10)),
 										},
 									},
 								},

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -35,6 +35,7 @@ type TraceJob struct {
 	ImageNameTag     string
 	InitImageNameTag string
 	FetchHeaders     bool
+	Deadline         int64
 	StartTime        metav1.Time
 	Status           TraceJobStatus
 }
@@ -217,6 +218,7 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 	job := &batchv1.Job{
 		ObjectMeta: commonMeta,
 		Spec: batchv1.JobSpec{
+			ActiveDeadlineSeconds:   int64Ptr(nj.Deadline),
 			TTLSecondsAfterFinished: int32Ptr(5),
 			Parallelism:             int32Ptr(1),
 			Completions:             int32Ptr(1),

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -300,7 +300,6 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							// We want to send SIGINT prior to the pod being killed, so we can print the map
 							// we will also wait for an arbitrary amount of time (10s) to give bpftrace time to
 							// process and summarize the data
-							// FIXME should this sleep be configurable? 10s is probably ample for most cases.
 							Lifecycle: &apiv1.Lifecycle{
 								PreStop: &apiv1.Handler{
 									Exec: &apiv1.ExecAction{

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -23,21 +23,22 @@ type TraceJobClient struct {
 
 // TraceJob is a container of info needed to create the job responsible for tracing.
 type TraceJob struct {
-	Name             string
-	ID               types.UID
-	Namespace        string
-	ServiceAccount   string
-	Hostname         string
-	Program          string
-	PodUID           string
-	ContainerName    string
-	IsPod            bool
-	ImageNameTag     string
-	InitImageNameTag string
-	FetchHeaders     bool
-	Deadline         int64
-	StartTime        metav1.Time
-	Status           TraceJobStatus
+	Name                string
+	ID                  types.UID
+	Namespace           string
+	ServiceAccount      string
+	Hostname            string
+	Program             string
+	PodUID              string
+	ContainerName       string
+	IsPod               bool
+	ImageNameTag        string
+	InitImageNameTag    string
+	FetchHeaders        bool
+	Deadline            int64
+	DeadlineGracePeriod int64
+	StartTime           metav1.Time
+	Status              TraceJobStatus
 }
 
 // WithOutStream setup a file stream to output trace job operation information
@@ -306,7 +307,7 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 										Command: []string{
 											"/bin/bash",
 											"-c",
-											"kill -SIGINT $(pidof bpftrace) && sleep 10",
+											fmt.Sprintf("kill -SIGINT $(pidof bpftrace) && sleep %i", nj.DeadlineGracePeriod),
 										},
 									},
 								},


### PR DESCRIPTION
Fixes #80 and paves the way for #11 

I think this is pretty elegant and I have to give the credit for both ideas to @jerr 

This allows for ensuring that bpftrace is signalled with SIGINT to dump its map before exiting.

Have tested this and it works more reliably than the interactive traces via TTY attach.

A nice benefit is you can now collect data for a pre-set interval before exiting 😂 