### PR TITLE
fix: no job start time case

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -200,7 +200,7 @@ func jobsTablePrint(o io.Writer, jobs []tracejob.TraceJob) {
 
 // translateTimestampSince returns the elapsed time since timestamp in
 // human-readable approximation.
-func translateTimestampSince(timestamp metav1.Time) string {
+func translateTimestampSince(timestamp *metav1.Time) string {
 	if timestamp.IsZero() {
 		return "<unknown>"
 	}

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -35,7 +35,7 @@ type TraceJob struct {
 	ImageNameTag     string
 	InitImageNameTag string
 	FetchHeaders     bool
-	StartTime        metav1.Time
+	StartTime        *metav1.Time
 	Status           TraceJobStatus
 }
 
@@ -131,7 +131,7 @@ func (t *TraceJobClient) GetJob(nf TraceJobFilter) ([]TraceJob, error) {
 			ID:        types.UID(id),
 			Namespace: j.Namespace,
 			Hostname:  hostname,
-			StartTime: *j.Status.StartTime,
+			StartTime: j.Status.StartTime,
 			Status:    jobStatus(j),
 		}
 		tjobs = append(tjobs, tj)


### PR DESCRIPTION
In some cases, the job has no start time (`Job.Status.StartTime = nil`).
We keep the pointer values ​​and display `<unknown>` in the case of `nil` thanks to `timestamp.IsZero()`

```
func (t *Time) IsZero() bool {
	if t == nil {
		return true
	}
	return t.Time.IsZero()
}
```

Fixes: #87