### PR TITLE
docs: fix curl cmd for Linux OS #95

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The commands here show `amd64` versions, `386` versions are available in the rel
 **Linux**
 
 ```bash
-curl -Lo https://github.com/iovisor/kubectl-trace/releases/download/v0.1.0-rc.1/kubectl-trace_0.1.0-rc.1_linux_amd64.tar.gz
+curl -LO https://github.com/iovisor/kubectl-trace/releases/download/v0.1.0-rc.1/kubectl-trace_0.1.0-rc.1_linux_amd64.tar.gz
 tar -xvf kubectl-trace.tar.gz
 mv kubectl-trace /usr/local/bin/kubectl-trace
 ```


### PR DESCRIPTION
This PR edits curl cmd in README to fix curl error in linux os.
Fixes #95
