### PR TITLE
fix: Add blanket "NoSchedule" toleration to trace pod

### DIFF
--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -337,6 +337,12 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							},
 						},
 					},
+					Tolerations: []apiv1.Toleration{
+						apiv1.Toleration{
+							Effect:   apiv1.TaintEffectNoSchedule,
+							Operator: apiv1.TolerationOpExists,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We have a few nodes that we couldn't `kubectl trace` effectively because they were tainted to prevent arbitrary pods from being scheduled to them.

In this case, however, we are specifically requesting for a pod to be scheduled to that node, but the taint was leaving the pod hanging in `Pending` until we manually edited the trace pod to add this toleration.