### PR TITLE
fix: avoid mounting /usr/src for underlying Linux distros without it

### DIFF
--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -11,7 +11,8 @@ RUN make _output/bin/trace-runner
 FROM ubuntu:19.10
 ARG bpftraceversion=0.9.2-1
 RUN apt-get update && apt-get install -y bpftrace=${bpftraceversion} && \
-    rm -rf /var/lib/apt/lists/* && apt-get clean
+    rm -rf /var/lib/apt/lists/* && apt-get clean && \
+    rmdir /usr/src && ln -sf /usr-host/src /usr/src
 
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
 

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -247,10 +247,10 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 							},
 						},
 						apiv1.Volume{
-							Name: "usr-src-host",
+							Name: "usr-host",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
-									Path: "/usr/src",
+									Path: "/usr",
 								},
 							},
 						},
@@ -447,8 +447,8 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 		// If we aren't downloading headers, unconditionally used the ones linked in /lib/modules
 		job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts,
 			apiv1.VolumeMount{
-				Name:      "usr-src-host",
-				MountPath: "/usr/src",
+				Name:      "usr-host",
+				MountPath: "/usr-host",
 				ReadOnly:  true,
 			},
 			apiv1.VolumeMount{


### PR DESCRIPTION
Ubuntu has `/usr/src` with the kernel headers but on Flatcar Container Linux, this directory does not exist and the kernel headers are located in `/lib/modules/$(uname -r)` directly.

Attempting to mount `/usr/src` from the host causes Docker to attempt to create that directory but this does not work when the host /usr is read-only.

This patch mounts the host `/usr` into the tracerunner `/usr-host` instead because `/usr` always exists. Then, a symlink redirects `/usr/src` to `/usr-host/src` when needed.

Signed-off-by: Alban Crequy <alban@kinvolk.io>

Fixes https://github.com/iovisor/kubectl-trace/issues/102