### PR TITLE
feat: Bump bpftrace to v0.9.4 using new bpftrace docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_INITCONTAINER_LATEST := $(IMAGE_NAME_INIT):latest
 
 IMAGE_BUILD_FLAGS ?= "--no-cache"
 
-BPFTRACEVERSION ?= "0.9.2-1"
+BPFTRACEVERSION ?= "v0.9.4"
 
 LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageNameTag=${IMAGE_TRACERUNNER_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageNameTag=${IMAGE_INITCONTAINER_COMMIT}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)

--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -1,3 +1,6 @@
+ARG bpftraceversion=v0.9.4
+FROM quay.io/iovisor/bpftrace:$bpftraceversion as bpftrace
+
 FROM golang:1.11.4-stretch as gobuilder
 
 RUN apt-get update
@@ -9,11 +12,8 @@ WORKDIR /go/src/github.com/iovisor/kubectl-trace
 RUN make _output/bin/trace-runner
 
 FROM ubuntu:19.10
-ARG bpftraceversion=0.9.2-1
-RUN apt-get update && apt-get install -y bpftrace=${bpftraceversion} && \
-    rm -rf /var/lib/apt/lists/* && apt-get clean && \
-    rmdir /usr/src && ln -sf /usr-host/src /usr/src
 
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
+COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace
 
 ENTRYPOINT ["/bin/trace-runner"]


### PR DESCRIPTION
This moves the trace runner image to use bpftrace 0.9.4 using the static+glibc build approach I've been working on.

There is also a `latest` tag being pushed for quay.io/iovisor/bpftrace, which we might want to expose as an option as well (`eg, a flag like --latest`) so that daring users can run against bpftrace HEAD.

The resulting image is actually much smaller as it no longer needs to pull in a panoply of LLVM and Clang libraries - these are statically compiled in. The bpftrace binary is about 40MB, which is comparable to the alpine image kubectl-trace originally used.

We could aim to slim the image down further if we can find a dockerfile that includes pretty much just glibc for a base image