### PR TITLE
feat: support Amazon Linux when fetching headers

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -4,7 +4,7 @@ RUN apk add --update \
     bc \
     build-base \
     curl \
-    libelf-dev \
+    elfutils-dev \
     linux-headers \
     make
 

--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -14,7 +14,11 @@ generate_headers()
   echo "Generating kernel headers"
 
   cd "${BUILD_DIR}"
-  zcat /proc/config.gz > .config
+  if [ -e /proc/config.gz ]; then
+    zcat /proc/config.gz > .config
+  elif [ -e "/boot.host/config-${KERNEL_VERSION}" ]; then
+    cp "/boot.host/config-${KERNEL_VERSION}" .config
+  fi
   make ARCH=x86 oldconfig > /dev/null
   make ARCH=x86 prepare > /dev/null
 
@@ -32,7 +36,10 @@ fetch_cos_linux_sources()
 
 fetch_generic_linux_sources()
 {
-  kernel_version="$(echo "${KERNEL_VERSION}" | awk -vFS=+ '{ print $1 }')"
+  # 4.19.76-linuxkit -> 4.19.76
+  # 4.14.154-128.181.amzn2.x86_64 -> 4.14.154
+  # 4.19.76+gcp-something -> 4.19.76
+  kernel_version="$(echo "${KERNEL_VERSION}" | awk -vFS='[-+]' '{ print $1 }')"
   major_version="$(echo "${KERNEL_VERSION}" | awk -vFS=. '{ print $1 }')"
 
   echo "Fetching upstream kernel sources for ${kernel_version}."

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -349,7 +349,7 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 	}
 
 	if nj.FetchHeaders {
-		// If we aren't downloading headers, add the initContainer and set up mounts
+		// If we are downloading headers, add the initContainer and set up mounts
 		job.Spec.Template.Spec.InitContainers = []apiv1.Container{
 			apiv1.Container{
 				Name:  "kubectl-trace-init",
@@ -388,6 +388,10 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 						Name:      "linux-headers-generated",
 						MountPath: "/usr/src/",
 					},
+					apiv1.VolumeMount{
+						Name:      "boot-host",
+						MountPath: "/boot.host",
+					},
 				},
 			},
 		}
@@ -422,6 +426,14 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 				VolumeSource: apiv1.VolumeSource{
 					HostPath: &apiv1.HostPathVolumeSource{
 						Path: "/var/cache/linux-headers/generated",
+					},
+				},
+			},
+			apiv1.Volume{
+				Name: "boot-host",
+				VolumeSource: apiv1.VolumeSource{
+					HostPath: &apiv1.HostPathVolumeSource{
+						Path: "/boot",
 					},
 				},
 			})


### PR DESCRIPTION
* check /boot on host for kernel config in addition to /proc/config.gz
* improve kernel version splitting when downloading kernel sources
* use elfutils-dev instead of libelf-dev to support preparing headers with kernel version used by Amazon Linux

RPMs for kernel source/headers are available, somehow, but it seems
older versions are not kept around or are hard to track down.