### PR TITLE
fix: .0 version number in kernel sources

### DIFF
--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -42,6 +42,11 @@ fetch_generic_linux_sources()
   kernel_version="$(echo "${KERNEL_VERSION}" | awk -vFS='[-+]' '{ print $1 }')"
   major_version="$(echo "${KERNEL_VERSION}" | awk -vFS=. '{ print $1 }')"
 
+  # Remove the '.0' as the intial kernel major release isn't published with a patch number. 
+  if [[ $kernel_version == *.0 ]]; then
+    kernel_version=$(echo $kernel_version | rev | sed s/0\.// | rev)
+  fi
+
   echo "Fetching upstream kernel sources for ${kernel_version}."
   mkdir -p "${BUILD_DIR}"
   curl -sL "https://www.kernel.org/pub/linux/kernel/v${major_version}.x/linux-$kernel_version.tar.gz" \


### PR DESCRIPTION
The version of kubernetes I am using runs on an Ubuntu 4.15.0-88-generic kernel

When using HEAD 
```
kubectl trace run  xxx.xxx.xxx.xxx -e 'kprobe:do_sys_open { printf("%s: %s\n", comm, str(arg1)) }' --imagename quay.io/iovisor/kubectl-trace-bpftrace:HEAD --init-imagename=quay.io/iovisor/kubectl-trace-init:HEAD --fetch-headers 
```
the init container failed with 
```
+ mkdir -p /linux-generic-4.15.0-88-generic
+ curl -sL https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.15.0.tar.gz
+ tar --strip-components=1 -xzf - -C /linux-generic-4.15.0-88-generic
tar: invalid magic
tar: short read
real	0m0.112s
```
Navigating to https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/linux-4.15.0.tar.gz returns a 404.

Looking in the redirected root folder https://mirrors.edge.kernel.org/pub/linux/kernel/v4.x/ it would appear that initial major releases aren't given a .0 suffix. 
They just get a major and minor. e.g. linux-4.15.tar.gz

This patch fixes this issue by testing if the kernel version ends in .0 and removing it.
I've used `rev` to keep the regex comprehensible - hope you don't find it too verbose.

Tested with
[docker.io/number9/kubectl-trace-init:patchno-test-01](https://hub.docker.com/layers/number9/kubectl-trace-init/patchno-test-01/images/sha256-6fb9ff7221effdf657a63aa1f3383d5de4b950ecea169a0e1aab3275ec0f10da?context=repo)

```
kubectl trace run  XXX.XXX.XXX.XXX -e 'kprobe:do_sys_open { printf("%s: %s\n", comm, str(arg1)) }' --imagename quay.io/iovisor/kubectl-trace-bpftrace:HEAD --init-imagename=docker.io/number9/kubectl-trace-init:patchno-test-01 --fetch-headers  
```
