### PR TITLE
build: add flex and bison packages to init container

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -3,6 +3,8 @@ RUN apk add --update \
     bash \
     bc \
     build-base \
+    bison \
+    flex \
     curl \
     elfutils-dev \
     linux-headers \


### PR DESCRIPTION
`kubectl trace --fetch-headers` fails on GKE for me because flex and bison are needed during the `make` steps. Adding these packages to the init container fixes the problem.