### PR TITLE
fix: Update init container for newer versions of COS

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -6,6 +6,8 @@ RUN apk add --update \
     curl \
     elfutils-dev \
     linux-headers \
+    flex \
+    bison \
     make
 
 WORKDIR /

--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -56,7 +56,7 @@ fetch_generic_linux_sources()
 install_cos_linux_headers()
 {
   if grep -q CHROMEOS_RELEASE_VERSION "${LSB_FILE}" >/dev/null; then
-    BUILD_ID=$(awk '/CHROMEOS_RELEASE_VERSION =/ { print $3 }' "${LSB_FILE}")
+    BUILD_ID=$(awk -F ' *= *' '$1 == "CHROMEOS_RELEASE_VERSION" { print $2}' "$LSB_FILE")
     BUILD_DIR="/linux-lakitu-${BUILD_ID}"
     SOURCES_DIR="${TARGET_DIR}/linux-lakitu-${BUILD_ID}"
 
@@ -88,7 +88,7 @@ install_generic_linux_headers()
 
 install_headers()
 {
-  distro="$(awk '/^NAME =/ { print $3 }' "${OS_RELEASE_FILE}")"
+  distro=$(. "${OS_RELEASE_FILE}" && echo $NAME)
 
   case $distro in
     *"Container-Optimized OS"*)


### PR DESCRIPTION
It looks like newer versions of COS have removed some key whitespace in the LSB files that broke the fetch headers script. In addition, the header generation appears to need flex and bison now.

This was tested on GKE 1.15.11. While the changes *should* be backwards compatible, I haven't tested them on older versions of GKE yet.