### PR TITLE
fix: header generation issues on new GKE clusters

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -3,6 +3,8 @@ RUN apk add --update \
     bash \
     bc \
     build-base \
+    bison \
+    flex \
     curl \
     elfutils-dev \
     linux-headers \

--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -56,7 +56,7 @@ fetch_generic_linux_sources()
 install_cos_linux_headers()
 {
   if grep -q CHROMEOS_RELEASE_VERSION "${LSB_FILE}" >/dev/null; then
-    BUILD_ID=$(awk '/CHROMEOS_RELEASE_VERSION =/ { print $3 }' "${LSB_FILE}")
+    BUILD_ID=$(awk '/CHROMEOS_RELEASE_VERSION *= */ { gsub(/^CHROMEOS_RELEASE_VERSION *= */, ""); print }' "${LSB_FILE}")
     BUILD_DIR="/linux-lakitu-${BUILD_ID}"
     SOURCES_DIR="${TARGET_DIR}/linux-lakitu-${BUILD_ID}"
 
@@ -88,7 +88,7 @@ install_generic_linux_headers()
 
 install_headers()
 {
-  distro="$(awk '/^NAME =/ { print $3 }' "${OS_RELEASE_FILE}")"
+  distro="$(awk '/^NAME *= */ { gsub(/^NAME *= */, ""); print }' "${OS_RELEASE_FILE}")"
 
   case $distro in
     *"Container-Optimized OS"*)


### PR DESCRIPTION
This combines the efforts in #110 and #111 .

I ran a basic probe against a GKE cluster:

```
$ kubectl trace run $POD --fetch-headers -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }' -a
```

and got:

```
kconfig.h:5:10: fatal error: 'generated/autoconf.h' file not found"
```

With some testing I realized I needed the Google COS detection fixes in #111 with the `bison` and `flex` dependency fixes in #110 (without them I get a missing package error). This PR combines the fixes from both of those PRs, dropping the `linux-lts-dev` package addition in #111 since that is not needed in light of the finer-grained `bison` and `flex` deps.

**Modifications:**
- build: add flex and bison packages to init container
- fix: google container os detection

Co-authored-by: Adelbert Chang <achang@octoml.ai>
Co-authored-by: Will Milton <wa.milton@gmail.com>
Co-authored-by: dan <dan-ri@users.noreply.github.com>