### PR TITLE
feat: Support "native" BCC tools

### DIFF
--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -16,4 +16,7 @@ FROM ubuntu:19.10
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
 COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace
 
+RUN apt-get update
+RUN apt-get install -y bpfcc-tools
+
 ENTRYPOINT ["/bin/trace-runner"]

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -309,22 +309,45 @@ func (o *RunOptions) Run() error {
 		ConfigClient: coreClient.ConfigMaps(o.namespace),
 	}
 
-	tj := tracejob.TraceJob{
-		Name:                fmt.Sprintf("%s%s", meta.ObjectNamePrefix, string(juid)),
-		Namespace:           o.namespace,
-		ServiceAccount:      o.serviceAccount,
-		ID:                  juid,
-		Hostname:            o.nodeName,
-		Program:             o.bpftraceProgram,
-		IsBcc:               o.isBcc,
-		PodUID:              o.podUID,
-		ContainerName:       o.container,
-		IsPod:               o.isPod,
-		ImageNameTag:        o.imageName,
-		InitImageNameTag:    o.initImageName,
-		FetchHeaders:        o.fetchHeaders,
-		Deadline:            o.deadline,
-		DeadlineGracePeriod: o.deadlineGracePeriod,
+	var tj tracejob.TraceJob
+	if !o.isBcc {
+		tj = tracejob.TraceJob{
+			Name:                fmt.Sprintf("%s%s", meta.ObjectNamePrefix, string(juid)),
+			Namespace:           o.namespace,
+			ServiceAccount:      o.serviceAccount,
+			ID:                  juid,
+			Hostname:            o.nodeName,
+			Program:             o.bpftraceProgram,
+			ProgramArgs:         []string{},
+			IsBcc:               o.isBcc,
+			PodUID:              o.podUID,
+			ContainerName:       o.container,
+			IsPod:               o.isPod,
+			ImageNameTag:        o.imageName,
+			InitImageNameTag:    o.initImageName,
+			FetchHeaders:        o.fetchHeaders,
+			Deadline:            o.deadline,
+			DeadlineGracePeriod: o.deadlineGracePeriod,
+		}
+	} else {
+		tj = tracejob.TraceJob{
+			Name:                fmt.Sprintf("%s%s", meta.ObjectNamePrefix, string(juid)),
+			Namespace:           o.namespace,
+			ServiceAccount:      o.serviceAccount,
+			ID:                  juid,
+			Hostname:            o.nodeName,
+			Program:             o.bccTool,
+			ProgramArgs:         o.bccArgs,
+			IsBcc:               o.isBcc,
+			PodUID:              o.podUID,
+			ContainerName:       o.container,
+			IsPod:               o.isPod,
+			ImageNameTag:        o.imageName,
+			InitImageNameTag:    o.initImageName,
+			FetchHeaders:        o.fetchHeaders,
+			Deadline:            o.deadline,
+			DeadlineGracePeriod: o.deadlineGracePeriod,
+		}
 	}
 
 	job, err := tc.CreateJob(tj)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -159,6 +159,7 @@ func (o *RunOptions) Validate(cmd *cobra.Command, args []string) error {
 	if numArgs == 1 {
 		o.resourceArg = args[0]
 	} else if numArgs >= 2 && bccFlagDefined {
+		o.resourceArg = args[0]
 		o.bccArgs = args[1:]
 	} else {
 		return fmt.Errorf(requiredArgErrString)

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -74,7 +74,7 @@ func (o *TraceRunnerOptions) Validate(cmd *cobra.Command, args []string) error {
 		o.isBcc = true
 		// The image installs BCC through the Ubuntu package which suffixes all the tools with -bpfcc,
 		// e.g. memleak becomes memleak-bpfcc
-		bpfccSuffix := "bpfcc"
+		bpfccSuffix := "-bpfcc"
 		if !strings.HasSuffix(o.bccTool, bpfccSuffix) {
 			o.bccTool += bpfccSuffix
 		}

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -30,6 +30,7 @@ type TraceJob struct {
 	ServiceAccount      string
 	Hostname            string
 	Program             string
+	IsBcc               bool
 	PodUID              string
 	ContainerName       string
 	IsPod               bool
@@ -184,6 +185,7 @@ func (t *TraceJobClient) DeleteJobs(nf TraceJobFilter) error {
 	return nil
 }
 
+// TODO: thread through bcc call
 func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 
 	bpfTraceCmd := []string{


### PR DESCRIPTION
Fixes #112 

- install BCC in trace-runner image
- add `--bcc` flag to kubectl-trace and support threading through positional arguments
- thread through BCC arguments all the way down to and through trace-runner
- drop support for specifying container via position arguments to simplify parsing logic - specifying container is still supported via `-c`

Haven't tested this yet, but putting it up for early review. Basic idea is to add a new `--bcc` flag to kubectl-trace and propagate any args all the way through to trace-runner.