### PR TITLE
fix: some kernels require openssl-dev to generate headers

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -8,7 +8,8 @@ RUN apk add --update \
     curl \
     elfutils-dev \
     linux-headers \
-    make
+    make \
+    openssl-dev
 
 WORKDIR /
 


### PR DESCRIPTION
An attempt to generate headers for kernel `5.4.15-1.el7.elrepo.x86_64` failed in scripts/extract-cert.c due to missing openssl-dev package.

Error:
```
...
- make ARCH=x86 prepare
  scripts/extract-cert.c:21:25: fatal error: openssl/bio.h: No such file or directory
  #include <openssl/bio.h>
  ^
  compilation terminated.
```

Full init container log attached:
[init-container-fetch-headers.log](https://github.com/iovisor/kubectl-trace/files/4897175/init-container-fetch-headers.log)
