### PR TITLE
feat: add xz-utils in container image for CONFIG_IKHEADERS support

### DIFF
--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -13,6 +13,9 @@ RUN make _output/bin/trace-runner
 
 FROM ubuntu:19.10
 
+RUN apt-get update
+RUN apt-get install -y xz-utils
+
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
 COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace
 


### PR DESCRIPTION
This is one step to be able to use kernel headers from `CONFIG_IKHEADERS` in Minikube.

Note that it is not enough to make kubectl-trace work on Minikube, see other tasks in https://github.com/iovisor/kubectl-trace/issues/120.