### PR TITLE
feat: Allow patches to be applied to the job spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ of [bpftrace](https://github.com/iovisor/bpftrace) programs in your Kubernetes c
   * [Running against a Pod vs against a Node](#running-against-a-pod-vs-against-a-node)
   * [Using a custom service account](#using-a-custom-service-account)
   * [Executing in a cluster using Pod Security Policies](#executing-in-a-cluster-using-pod-security-policies)
+  * [Using a patch to customize the trace job](#using-a-patch-to-customize-the-trace-job)
   * [More bpftrace programs](#more-bpftrace-programs)
 - [Status of the project](#status-of-the-project)
 - [Contributing](#contributing)
@@ -266,6 +267,72 @@ If you used a different namespace other than default for your service account, y
 
 ```bash
 kubectl trace run --namespace=mynamespace --serviceaccount=kubectltrace ip-180-12-0-152.ec2.internal -f read.bt
+```
+
+### Using a patch to customize the trace job
+
+There may be times when you need to customize the job descriptor that kubectl-trace generates. You can provide a patch file that will modify any of the job's attributes before it executes on the cluster.
+
+The the `--patch` and `--patch-type` arguments to the `run` command specify your patch file's location and merge strategy:
+
+ * `--patch` - sets the path to a YAML or JSON file containing your patch.
+ * `--patch-type` - sets the strategy that will be used to modify the job descriptor.
+
+**Patch strategies**
+
+The supported patch strategies are the same as those used by Kubernetes to support [in-place API object updates](https://v1-17.docs.kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+These 3 patch strategies are:
+
+ - `json` - Sets the [JSON patch](http://jsonpatch.com/) strategy (see [RFC 6209](https://tools.ietf.org/html/rfc6902)).
+ - `merge` - Sets the [JSON merge patch](https://tools.ietf.org/html/rfc7396) strategy.
+ - `strategic` - [JSON strategic merge patch]() is like the "JSON merge patch" but with different array handling (see [Kubernetes strategic merge](https://v1-17.docs.kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment) for more).
+
+**Note:** You can create your patch files in either YAML or JSON format. The format is independent of the strategy used, e.g. the strategy `json` refers to the "JSON patch" strategy, not the format of the patch file.
+
+**Example: customizing resource limits**
+
+A cluster administrator may have set strict resource limits that conflict with the defaults used by `kubectl-trace`, preventing your job from executing. With a patch you can adjust a job's resource limits to match your cluster's config.
+
+Below is an example of a YAML patch which uses the `json` strategy ("JSON patch"). This strategy consists of a list of operations (add, replace, remove), a path which references a location in the document, and an optional value (to add or replace).
+
+The patch below replaces the first container's resources section, in order to increase both the request and limit values for cpu and memory:
+
+```yaml
+# mypatch.yaml
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 2
+      memory: 500Mi
+    requests:
+      cpu: 2
+      memory: 500Mi
+```
+
+We can now run the job using our patch:
+
+```bash
+kubectl trace run ip-180-12-0-152.ec2.internal -f read.bt --patch mypatch.yaml --patch-type json
+```
+
+**Example: setting an environment variable**
+
+The following JSON format patch adds a `BPFTRACE_STRLEN` environment variable to the first container. The variable increases `bpftrace`'s string length limit from 64 to 128:
+
+```json
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/env",
+    "value": [{ "name": "BPFTRACE_STRLEN", "value": "128" }]
+  }
+]
+```
+
+```bash
+kubectl trace run ip-180-12-0-152.ec2.internal -f read.bt --patch mypatch.json --patch-type json
 ```
 
 ### More bpftrace programs

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/iovisor/kubectl-trace
 go 1.15
 
 require (
+	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/fntlnz/mountinfo v0.0.0-20171106231217-40cb42681fad
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/pkg/errors v0.9.1
@@ -16,4 +17,5 @@ require (
 	k8s.io/client-go v0.19.3
 	k8s.io/kubectl v0.19.3
 	sigs.k8s.io/kind v0.9.0
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/tracejob/job_test.go
+++ b/pkg/tracejob/job_test.go
@@ -1,0 +1,75 @@
+package tracejob
+
+import (
+	"reflect"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+type patchTest struct {
+	patchType string
+	patch     []byte
+}
+
+var patchJSON1 = []byte(`
+- op: replace
+  path: "/spec/backOffLimit"
+  value: 123
+- op: add
+  path: "/spec/template/hostPID"
+  value: true
+- op: remove
+  path: "/spec/completions"
+`)
+var patchJSON2 = []byte(`[
+  { "op": "replace", "path": "/spec/backOffLimit", "value": 123 },
+  { "op": "add", "path": "/spec/template/hostPID", "value": true },
+  { "op": "remove", "path": "/spec/completions"}
+]`)
+
+var patchMerge = []byte(`
+spec:
+  backoffLimit: 123
+  completions: null
+  template:
+    hostPID: true
+`)
+
+var testCases = []patchTest{
+	{patchType: "json", patch: patchJSON1},
+	{patchType: "json", patch: patchJSON2},
+	{patchType: "merge", patch: patchMerge},
+	{patchType: "strategic", patch: patchMerge},
+}
+
+func TestPatchJobJSON(t *testing.T) {
+	for _, c := range testCases {
+		job := getJob()
+		newJob, err := patchJob(job, c.patchType, c.patch)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Update expected value
+		job.Spec.BackoffLimit = int32Ptr(123)
+		job.Spec.Template.Spec.HostPID = true
+		job.Spec.Completions = nil
+
+		if reflect.DeepEqual(job, newJob) {
+			t.Errorf("patch %s job does not match expected", c.patchType)
+		}
+	}
+}
+
+func getJob() *batchv1.Job {
+	return &batchv1.Job{
+		Spec: batchv1.JobSpec{
+			ActiveDeadlineSeconds:   int64Ptr(60),
+			TTLSecondsAfterFinished: int32Ptr(5),
+			Parallelism:             int32Ptr(1),
+			Completions:             int32Ptr(1),
+			BackoffLimit:            int32Ptr(1),
+		},
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,6 +35,7 @@ github.com/docker/spdystream/spdy
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.9.0+incompatible
+## explicit
 github.com/evanphx/json-patch
 # github.com/evanphx/json-patch/v5 v5.1.0
 github.com/evanphx/json-patch/v5
@@ -506,4 +507,5 @@ sigs.k8s.io/kustomize/pkg/types
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml


### PR DESCRIPTION
I ran into an issue where I needed the ability to alter the job spec for clusters with resource constraints (reducing cpu usage 
to 0.5 core), or where a specific resource request/limit ratio is enforced.

Rather than add multiple command line flags for each of these properties, I added a feature to allow an operator to apply a patch to the job spec immediately before `t.JobClient.Create(job)` is called. Patches can be written in either YAML or JSON using one of 3 merge strategies: `json`, `merge`, `strategic`.

For example, to customize the resource limits, you can create `limits.json` with the contents:
```json
[
  {
    "op": "replace",
    "path": "/spec/template/spec/containers/0/resources",
    "value": {
      "limits": {
        "cpu": "0.5",
        "memory": "100Mi"
      },
      "requests": {
        "cpu": "0.5",
        "memory": "100Mi"
      }
    }
  }
]
```

Then run: `kubectl trace run -a node/minikube -f program.bt --patch limits.json --patch-type json`

I'm happy to revise this or withdraw it if there is a better way to achieve the same result.
