### PR TITLE
feat: Generic Tracers [POC]

### DIFF
--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -14,7 +14,7 @@ RUN make _output/bin/trace-runner
 FROM ubuntu:19.10
 
 RUN apt-get update
-RUN apt-get install -y xz-utils
+RUN apt-get install -y kmod xz-utils bpfcc-tools
 
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
 COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -194,7 +194,7 @@ func (o *TraceRunnerOptions) prepBpfTraceCommand() (*string, *string, error) {
 }
 
 func (o *TraceRunnerOptions) prepBccCommand() (*string, *string, error) {
-	return nil, nil, tracerNotImplemented(o.tracer)
+	return &o.program, nil, nil
 }
 
 func tracerNotImplemented(tracer string) error {


### PR DESCRIPTION
This is a proof of concept that defines a standard interface for `trace-runner` and `kubectl-trace` and then plugs in a new tracing backend `bcc`. It is not meant to be merged but will be referenced in my RFC.

Changes
- Decouple `trace-runner` from `bpftrace` and accept generic arguments.
- Switch tracing backend in `trace-runner` from arguments.
- Add generic `--tracer`, `--output` and `--program` flags to `kubectl-trace run` command.
- Plumb through run arguments to trace runner pretty much verbatim.