### PR TITLE
fix: Pin container images to latest stable release

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -22,9 +22,9 @@ import (
 
 var (
 	// ImageNameTag represents the default tracerunner image
-	ImageNameTag = "quay.io/iovisor/kubectl-trace-bpftrace:latest"
+	ImageNameTag = "quay.io/iovisor/kubectl-trace-bpftrace:93902512c7d983338aee08dd8d3712dcbf259b3a"
 	// InitImageNameTag represents the default init container image
-	InitImageNameTag = "quay.io/iovisor/kubectl-trace-init:latest"
+	InitImageNameTag = "quay.io/iovisor/kubectl-trace-init:93902512c7d983338aee08dd8d3712dcbf259b3a"
 	// DefaultDeadline is the maximum time a tracejob is allowed to run, in seconds
 	DefaultDeadline = 3600
 	// DefaultDeadlineGracePeriod is the maximum time to wait to print a map or histogram, in seconds


### PR DESCRIPTION
As part of the work on generic tracers the interface to trace-runner
will be changing and we don't want current users to break.

@dalehamel I have updated the image in the code directly but can also modify it through goreleaser if that is preferred.

https://github.com/iovisor/kubectl-trace/blob/master/.goreleaser.yml#L21

Fixes #129