### PR TITLE
feat: Upgrade bpftrace and base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ IMAGE_INITCONTAINER_LATEST := $(IMAGE_NAME_INIT):latest
 
 IMAGE_BUILD_FLAGS ?= "--no-cache"
 
-BPFTRACEVERSION ?= "v0.9.4"
+BPFTRACEVERSION ?= "v0.11.1"
 
 LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageNameTag=${IMAGE_TRACERUNNER_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageNameTag=${IMAGE_INITCONTAINER_COMMIT}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)

--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -1,4 +1,4 @@
-ARG bpftraceversion=v0.9.4
+ARG bpftraceversion=v0.11.1
 FROM quay.io/iovisor/bpftrace:$bpftraceversion as bpftrace
 
 FROM golang:1.11.4-stretch as gobuilder
@@ -11,7 +11,7 @@ WORKDIR /go/src/github.com/iovisor/kubectl-trace
 
 RUN make _output/bin/trace-runner
 
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt-get install -y xz-utils


### PR DESCRIPTION
Do some housekeeping and upgrade image to use latest versions of the tools. This is setting things up in preparation for #125 .

I have tested the upgraded image locally but open to more thorough testing as might be suggested.