### PR TITLE
feat: Refactor bpftrace functionality to generic tracer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 GIT_ORG ?= iovisor
 
 IMAGE_NAME_INIT ?= quay.io/$(GIT_ORG)/kubectl-trace-init
-IMAGE_NAME ?= quay.io/$(GIT_ORG)/kubectl-trace-bpftrace
+IMAGE_NAME ?= quay.io/$(GIT_ORG)/kubectl-trace-runner
 
 IMAGE_TRACERUNNER_BRANCH := $(IMAGE_NAME):$(GIT_BRANCH_CLEAN)
 IMAGE_TRACERUNNER_COMMIT := $(IMAGE_NAME):$(GIT_COMMIT)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -145,7 +145,7 @@ func NewRunCommand(factory cmdutil.Factory, streams genericclioptions.IOStreams)
 
 	// flags for existing usage
 	cmd.Flags().StringVarP(&o.container, "container", "c", o.container, "Specify the container")
-	cmd.Flags().StringVarP(&o.eval, "eval", "e", o.eval, "Literal string to be evaluated as a bpftrace program")
+	cmd.Flags().StringVarP(&o.eval, "eval", "e", o.eval, "DEPRECATED: Literal string to be evaluated as a bpftrace program")
 	cmd.Flags().StringVarP(&o.filename, "filename", "f", o.filename, "File containing a bpftrace program")
 
 	// flags for new generic interface

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -144,7 +144,7 @@ func NewRunCommand(factory cmdutil.Factory, streams genericclioptions.IOStreams)
 	}
 
 	// flags for existing usage
-	cmd.Flags().StringVarP(&o.container, "container", "c", o.container, "Specify the container")
+	cmd.Flags().StringVarP(&o.container, "container", "c", o.container, "DEPRECATED: Specify the container")
 	cmd.Flags().StringVarP(&o.eval, "eval", "e", o.eval, "DEPRECATED: Literal string to be evaluated as a bpftrace program")
 	cmd.Flags().StringVarP(&o.filename, "filename", "f", o.filename, "File containing a bpftrace program")
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	// ImageName represents the default tracerunner image
-	ImageName = "quay.io/iovisor/kubectl-trace-bpftrace"
+	ImageName = "quay.io/iovisor/kubectl-trace-runner"
 	// ImageTag represents the tag to fetch for ImageName
 	ImageTag = "latest"
 	// InitImageName represents the default init container image

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -188,12 +188,6 @@ func (o *TraceRunnerOptions) prepBpfTraceCommand() (*string, *string, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		if pid == nil {
-			return nil, nil, fmt.Errorf("pid not found")
-		}
-		if len(*pid) == 0 {
-			return nil, nil, fmt.Errorf("invalid pid found")
-		}
 		f, err := ioutil.ReadFile(programPath)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -16,12 +15,44 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	bpftrace = "bpftrace"
+	bcc      = "bcc"
+)
+
+var (
+	bpfTraceBinaryPath = "/usr/bin/bpftrace"
+)
+
 type TraceRunnerOptions struct {
-	podUID             string
-	containerName      string
-	inPod              bool
-	programPath        string
-	bpftraceBinaryPath string
+	// The tracing system to use.
+	// tracer = bpftrace | bcc | perf
+	tracer string
+
+	// Selector (label query) that identifies entity to be traced.
+	// selector = label '=' value [',' labelN '=' valueN ...]
+	// Currently supported labels:
+	// - node
+	//   Select a node by name
+	// - pod
+	//   Select a pod by name
+	// - pod-uid
+	//   Select a pod by UID
+	// - container
+	//   Select a container by name
+	selector string
+
+	// Where will the tracing system send output.
+	// output = stdout | file:///path | URI
+	output string
+
+	// In the case of bcc the name of the bcc program to execute.
+	// In the case of bpftrace the path to contents of the user provided expression or program.
+	program string
+
+	// In the case of bcc the user provided arguments to pass on to program.
+	// Not used for bpftrace.
+	programArgs string
 }
 
 func NewTraceRunnerOptions() *TraceRunnerOptions {
@@ -46,19 +77,28 @@ func NewTraceRunnerCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.containerName, "container", "c", o.containerName, "Specify the container")
-	cmd.Flags().StringVarP(&o.podUID, "poduid", "p", o.podUID, "Specify the pod UID")
-	cmd.Flags().StringVarP(&o.programPath, "program", "f", "program.bt", "Specify the bpftrace program path")
-	cmd.Flags().StringVarP(&o.bpftraceBinaryPath, "bpftracebinary", "b", "/bin/bpftrace", "Specify the bpftrace binary path")
-	cmd.Flags().BoolVar(&o.inPod, "inpod", false, "Whether or not run this bpftrace in a pod's container process namespace")
+	cmd.Flags().StringVar(&o.tracer, "tracer", "bpftrace", "Tracing system to use")
+	cmd.Flags().StringVar(&o.selector, "selector", "", "Selector (label query) to filter on")
+	cmd.Flags().StringVar(&o.output, "output", "stdout", "Where will the tracing system send output")
+	cmd.Flags().StringVar(&o.program, "program", "/programs/program.bt", "Tracer input script or executable")
+	cmd.Flags().StringVar(&o.programArgs, "program-args", o.programArgs, "Arguments to pass through to executable in --program")
 	return cmd
 }
 
 func (o *TraceRunnerOptions) Validate(cmd *cobra.Command, args []string) error {
-	// TODO(fntlnz): do some more meaningful validation here, for now just checking if they are there
-	if o.inPod == true && (len(o.containerName) == 0 || len(o.podUID) == 0) {
-		return fmt.Errorf("poduid and container must be specified when inpod=true")
+	switch o.tracer {
+	case bpftrace, bcc:
+	default:
+		return fmt.Errorf("unknown tracer %s", o.tracer)
 	}
+
+	switch o.output {
+	case "stdout":
+	default:
+		return fmt.Errorf("unknown output %s", o.output)
+	}
+
+	// TODO(zqureshi): parse and validate selector.
 	return nil
 }
 
@@ -68,28 +108,20 @@ func (o *TraceRunnerOptions) Complete(cmd *cobra.Command, args []string) error {
 }
 
 func (o *TraceRunnerOptions) Run() error {
-	programPath := o.programPath
-	if o.inPod == true {
-		pid, err := findPidByPodContainer(o.podUID, o.containerName)
-		if err != nil {
-			return err
-		}
-		if pid == nil {
-			return fmt.Errorf("pid not found")
-		}
-		if len(*pid) == 0 {
-			return fmt.Errorf("invalid pid found")
-		}
-		f, err := ioutil.ReadFile(programPath)
-		if err != nil {
-			return err
-		}
-		programPath = path.Join(os.TempDir(), "program-container.bt")
-		r := strings.Replace(string(f), "$container_pid", *pid, -1)
-		if err := ioutil.WriteFile(programPath, []byte(r), 0755); err != nil {
-			return err
-		}
+	var err error
+	var binary, args *string
+	switch o.tracer {
+	case bpftrace:
+		binary, args, err = o.prepBpfTraceCommand()
+	case bcc:
+		binary, args, err = o.prepBccCommand()
 	}
+
+	if err != nil {
+		return err
+	}
+
+	// Assume output is stdout until other backends are implemented.
 
 	fmt.Println("if your program has maps to print, send a SIGINT using Ctrl-C, if you want to interrupt the execution send SIGINT two times")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -116,11 +148,51 @@ func (o *TraceRunnerOptions) Run() error {
 		}
 	}()
 
-	c := exec.CommandContext(ctx, o.bpftraceBinaryPath, programPath)
+	var c *exec.Cmd
+	if args == nil || len(*args) == 0 {
+		c = exec.CommandContext(ctx, *binary)
+	} else {
+		c = exec.CommandContext(ctx, *binary, *args)
+	}
+
 	c.Stdout = os.Stdout
 	c.Stdin = os.Stdin
 	c.Stderr = os.Stderr
 	return c.Run()
+}
+
+func (o *TraceRunnerOptions) prepBpfTraceCommand() (*string, *string, error) {
+	programPath := o.program
+
+	// TODO(zqureshi): Filter using selector.
+	// Render $container_pid to actual process pid if scoped to container.
+	// if o.target == "container" {
+	// 	pid, err := findPidByPodContainer(o.podUID, o.containerName)
+	// 	if err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// 	if pid == nil {
+	// 		return nil, nil, fmt.Errorf("pid not found")
+	// 	}
+	// 	if len(*pid) == 0 {
+	// 		return nil, nil, fmt.Errorf("invalid pid found")
+	// 	}
+	// 	f, err := ioutil.ReadFile(programPath)
+	// 	if err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// 	programPath = path.Join(os.TempDir(), "program-container.bt")
+	// 	r := strings.Replace(string(f), "$container_pid", *pid, -1)
+	// 	if err := ioutil.WriteFile(programPath, []byte(r), 0755); err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// }
+
+	return &bpfTraceBinaryPath, &programPath, nil
+}
+
+func (o *TraceRunnerOptions) prepBccCommand() (*string, *string, error) {
+	return nil, nil, fmt.Errorf("tracer bcc not implemented")
 }
 
 func findPidByPodContainer(podUID, containerName string) (*string, error) {

--- a/pkg/tracejob/selector.go
+++ b/pkg/tracejob/selector.go
@@ -19,6 +19,11 @@ func NewSelector(query string) (*Selector, error) {
 		terms: map[string]string{},
 	}
 
+	query = strings.TrimSpace(query)
+	if len(query) == 0 {
+		return s, nil
+	}
+
 	terms := strings.Split(query, ",")
 	for _, t := range terms {
 		seg := strings.Split(t, "=")

--- a/pkg/tracejob/selector.go
+++ b/pkg/tracejob/selector.go
@@ -1,0 +1,72 @@
+package tracejob
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Selector represents a label query to select the entity to be traced.
+// Most commonly this entity would resolve into a host, pod or container.
+type Selector struct {
+	// label -> value, values cannot contain spaces.
+	// Assumes equality match, will be changed when more operators added.
+	terms map[string]string
+}
+
+// NewSelector will construct a selector by parsing the query.
+func NewSelector(query string) (*Selector, error) {
+	s := &Selector{
+		terms: map[string]string{},
+	}
+
+	terms := strings.Split(query, ",")
+	for _, t := range terms {
+		seg := strings.Split(t, "=")
+		if len(seg) != 2 {
+			return nil, fmt.Errorf("invalid term in selector at %s", t)
+		}
+
+		label, value := strings.TrimSpace(seg[0]), strings.TrimSpace(seg[1])
+		s.terms[label] = value
+	}
+
+	return s, nil
+}
+
+// Get a label by name.
+func (s *Selector) Get(label string) (string, bool) {
+	value, ok := s.terms[label]
+	return value, ok
+}
+
+// Set a label by name.
+// Returns the value just set.
+func (s *Selector) Set(label, value string) string {
+	s.terms[label] = value
+	return value
+}
+
+// String converts selector back to a query.
+func (s *Selector) String() string {
+	terms := []string{}
+	for k, v := range s.terms {
+		terms = append(terms, k+"="+v)
+	}
+	return strings.Join(terms, ",")
+}
+
+func (s *Selector) Node() (string, bool) {
+	return s.Get("node")
+}
+
+func (s *Selector) Pod() (string, bool) {
+	return s.Get("pod")
+}
+
+func (s *Selector) PodUID() (string, bool) {
+	return s.Get("pod-uid")
+}
+
+func (s *Selector) Container() (string, bool) {
+	return s.Get("container")
+}

--- a/pkg/tracejob/selector_test.go
+++ b/pkg/tracejob/selector_test.go
@@ -1,0 +1,61 @@
+package tracejob
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	. "github.com/go-check/check"
+)
+
+type SelectorSuite struct{}
+
+func init() {
+	Suite(&SelectorSuite{})
+}
+
+func Test(t *testing.T) { TestingT(t) }
+
+// sorted will output a query like selector.String() but with terms in order.
+func sorted(s *Selector) string {
+	terms := sort.StringSlice{}
+	for k, v := range s.terms {
+		terms = append(terms, k+"="+v)
+	}
+	terms.Sort()
+	return strings.Join(terms, ",")
+}
+
+func (s *SelectorSuite) TestNewSlice(c *C) {
+	parsed, err := NewSelector("foo=bar, abc=xyz")
+	c.Assert(err, IsNil)
+	c.Assert(sorted(parsed), Equals, "abc=xyz,foo=bar")
+}
+
+func (s *SelectorSuite) TestNewSliceError(c *C) {
+	// Would do a table test if more than 3 cases.
+	_, err := NewSelector("pod=hello-world node=minikube")
+	c.Assert(err, NotNil)
+
+	_, err = NewSelector("pod=hello-world,, node=minikube")
+	c.Assert(err, NotNil)
+}
+
+func (s *SelectorSuite) TestString(c *C) {
+	expected := &Selector{
+		terms: map[string]string{
+			"foo": "bar",
+			"abc": "xyz",
+		},
+	}
+
+	parsed, _ := NewSelector("foo=bar, abc=xyz")
+	c.Assert(parsed, DeepEquals, expected)
+}
+
+func (s *SelectorSuite) TestNode(c *C) {
+	parsed, _ := NewSelector("pod=hello-world, node=minikube")
+	val, ok := parsed.Node()
+	c.Assert(ok, Equals, true)
+	c.Assert(val, Equals, "minikube")
+}


### PR DESCRIPTION
This PR introduces the tracer interface as described in the [RFC](https://docs.google.com/document/d/1Ip4D_vc-aOyVP2EsvgF_sxgBNngTPrxPk8Ybw6j4_6g/edit) and #125 while maintaining full backwards compatibility.

The goal was to make the minimal amount of changes that would get us to the new world but leave more feature implementations to future PRs. While working on the code and after some discussions I also tweaked the interface to remove the `--target` flag and just have a single `--selector` flag.

Review guide:
- Review `TraceRunnerOptions` and verify new fields.
- Review `RunOptions` changes, focusing on the new fields that mirror tracerunner.
- I renamed image from `kubectl-trace-bpftrace` to `kubectl-trace-runner`.
- Review [Selector](https://github.com/iovisor/kubectl-trace/pull/136/files#diff-b57f265d7e29aabfcb36e32ada2984df867c3b7e81d1b95e26539b0da070ca12) and accessors. This represents a k8s label query but with accessors for each field.
- Go to [tracerunner](https://github.com/iovisor/kubectl-trace/pull/136/files#diff-43ad48182bb415af9c97abf39d10fd3e78a2755559f0d635da6dd3020a22be52R127) and review the `Validate()` and `Run()` methods.

  For a simple `kubectl trace -e '<bpf_script>' minikube` the generated runner command will be `trace-runner --tracer=bpftrace --selector=node=minikube --output=stdout --program=/programs/program.bt`

  When selecting a pod / container the generated selector will have `pod-uid=<uuid>,container=<name>` so review the `$container_pid` substitution that leverages [that](https://github.com/iovisor/kubectl-trace/pull/136/files#diff-43ad48182bb415af9c97abf39d10fd3e78a2755559f0d635da6dd3020a22be52R184).
- Now get to [run.go](https://github.com/iovisor/kubectl-trace/pull/136/files#diff-d9b5c5a6245814d60e99f92a71feb162ec636c09f5787321970e26ef80fb736bR239) and review the `Complete()` method changes and how [job.go](https://github.com/iovisor/kubectl-trace/pull/136/files#diff-6c50df8d5924b03f85013c687895c9f95d43d0f704a18ae6abbf752ea6d7c916R189) builds the `traceCmd`.
- The last (and trickiest) part is to focus on the `Validate()` changes in `run.go` and how they maintain backwards compatibility.

  Design choices to review
  - The `--selector` flag can only be used with `--tracer`. This is to ensure that users don't mix old and new functionality.
  - The `--program`, `--eval` and `--file` flags are interchangeable and they just populate the `o.program` field eventually (as in the previous implementation.)
  - When using `--selector` all filters like `node`, `pod` and `container` must be passed in via the flag and cannot be provided via positional arguments.
  - When the run command is finding the right entity, it will update the `parsedSelector` with updated `node`, `pod` and `container` values. This removes the local `podUID` field and changes the behaviour of the `container` field to only take flag input and no updates.
  - When using `--selector` the resource filtering is still done through `resourceArg` and the arg value is populated in order of specificity (node -> pod.)
- **Note:** I have strayed from adding tests just yet so that we can align on code changes but will add integration tests once we have initial review.

As an example of how convenient it would be to add a new backend I have reworked #117 on top of this in my own branch https://github.com/zqureshi/kubectl-trace/pull/1 @adelbertc.

@dalehamel @fntlnz @leodido 

