### PR TITLE
feat: Set up automated releases via krew

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -27,3 +27,5 @@ jobs:
           make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.38

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: trace
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/iovisor/kubectl-trace
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-trace
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: 386
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_darwin_386.tar.gz" .TagName }}
+    bin: kubectl-trace
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-trace
+  - selector:
+      matchLabels:
+        os: linux
+        arch: 386
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_linux_386.tar.gz" .TagName }}
+    bin: kubectl-trace
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
+    bin: kubectl-trace.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_windows_386.tar.gz" .TagName }}
+    bin: kubectl-trace.exe
+  shortDescription: Trace Kubernetes pods and nodes with system tools
+  description: |
+    Usage:
+      Read more documentation at: https://github.com/iovisor/kubectl-trace


### PR DESCRIPTION
This is an attempt to fix #119 

@rajatjindal does this look correct to you? We already had goreleaser being called in github actions (see makefile), so I think that if the bot works as expected, this should be able to grab the artifacts from the release that is published?

@leodido @fntlnz 

cc @zqureshi 