### PR TITLE
feat: Pin tagged release to container with same SHA

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,8 @@ builds:
     ldflags: |
       -X github.com/iovisor/kubectl-trace/pkg/version.buildTime={{ .Timestamp }}
       -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit={{ .Commit }}
-      -X github.com/iovisor/kubectl-trace/pkg/version.imageName={{ .Env.IMAGE_NAME }}
+      -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageTag={{ .Commit }}
+      -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageTag={{ .Commit }}
     binary: kubectl-trace
   - id: "trace-runner"
     goos:
@@ -35,7 +36,8 @@ builds:
     ldflags: |
       -X github.com/iovisor/kubectl-trace/pkg/version.buildTime={{ .Timestamp }}
       -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit={{ .Commit }}
-      -X github.com/iovisor/kubectl-trace/pkg/version.imageName={{ .Env.IMAGE_NAME }}
+      -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageTag={{ .Commit }}
+      -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageTag={{ .Commit }}
     binary: trace-runner
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMAGE_BUILD_FLAGS ?= "--no-cache"
 
 BPFTRACEVERSION ?= "v0.11.1"
 
-LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageNameTag=${IMAGE_TRACERUNNER_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageNameTag=${IMAGE_INITCONTAINER_COMMIT}'
+LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageName=${IMAGE_NAME} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageTag=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageName=${IMAGE_NAME_INIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageTag=${GIT_COMMIT}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)
 
 kubectl_trace ?= _output/bin/kubectl-trace

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -68,7 +68,7 @@ func (k *KubectlTraceSuite) SetUpSuite(c *check.C) {
 	defer os.RemoveAll(dir)
 	imageTarPath := filepath.Join(dir, "image.tar")
 
-	err = save(cmd.ImageNameTag, imageTarPath)
+	err = save(cmd.ImageName+":"+cmd.ImageTag, imageTarPath)
 	c.Assert(err, check.IsNil)
 
 	// Copy the bpftrace image to the nodes

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -21,10 +21,14 @@ import (
 )
 
 var (
-	// ImageNameTag represents the default tracerunner image
-	ImageNameTag = "quay.io/iovisor/kubectl-trace-bpftrace:latest"
-	// InitImageNameTag represents the default init container image
-	InitImageNameTag = "quay.io/iovisor/kubectl-trace-init:latest"
+	// ImageName represents the default tracerunner image
+	ImageName = "quay.io/iovisor/kubectl-trace-bpftrace"
+	// ImageTag represents the tag to fetch for ImageName
+	ImageTag = "latest"
+	// InitImageName represents the default init container image
+	InitImageName = "quay.io/iovisor/kubectl-trace-init"
+	// InitImageTag represents the tag to fetch for InitImage
+	InitImageTag = "latest"
 	// DefaultDeadline is the maximum time a tracejob is allowed to run, in seconds
 	DefaultDeadline = 3600
 	// DefaultDeadlineGracePeriod is the maximum time to wait to print a map or histogram, in seconds
@@ -96,8 +100,8 @@ func NewRunOptions(streams genericclioptions.IOStreams) *RunOptions {
 		IOStreams: streams,
 
 		serviceAccount:      "default",
-		imageName:           ImageNameTag,
-		initImageName:       InitImageNameTag,
+		imageName:           ImageName + ":" + ImageTag,
+		initImageName:       InitImageName + ":" + InitImageTag,
 		deadline:            int64(DefaultDeadline),
 		deadlineGracePeriod: int64(DefaultDeadlineGracePeriod),
 	}


### PR DESCRIPTION
Successor to #130 but instead of changing things in code use linker flags for goreleaser.

This splits `ImageNameTag` into `ImageName` and `ImageTag` so that `ImageTag` can be overridden independently from `.goreleaser.yml`. Similarly for `InitImageNameTag`.

This change is fully backwards compatible and both the `--imagename` and `--init-imagename` flags work as expected.

Fixes #129 

@dalehamel @fntlnz @leodido 