### PR TITLE
fix: Race condition in attacher looking for pod

### DIFF
--- a/pkg/attacher/attach.go
+++ b/pkg/attacher/attach.go
@@ -68,7 +68,9 @@ func (a *Attacher) Attach(selector, namespace string) {
 			}
 
 			if len(pl.Items) == 0 {
-				return false, fmt.Errorf(podNotFoundError)
+				// A job might have been created but the pod scheduling could have been delayed
+				// therefore we cannot simply error out here and must continue retrying.
+				return false, nil
 			}
 			pod := &pl.Items[0]
 			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {


### PR DESCRIPTION
Fixes #84 

When you do `kubectl trace run --attach` the job will have been created by `TraceJobClient` but the pod is not guaranteed to have been scheduled on any node. Therefore we cannot error out if no pod is found and must continue retrying.

It is easy to reproduce if you put a `panic()` in that area and I seem to hit it about 20% of my runs.

I also made it so that all errors encountered by the attacher are logged because they were silent right now and you wouldn't know that you attached to a blank `bpftrace` screen or attach failed and the local process is just waiting for a Ctrl-C.

@dalehamel @fntlnz 