### PR TITLE
fix: Format get cmd output.

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -174,7 +174,7 @@ func (o *GetOptions) Run() error {
 // TODO(fntlnz): This needs better printing, perhaps we could use the humanreadable table from k8s itself
 // to be consistent with the main project.
 func jobsTablePrint(o io.Writer, jobs []tracejob.TraceJob) {
-	format := "%s\t%s\t%s\t%s\t%s\t"
+	format := "%s \t %s \t %s \t %s \t %s\t"
 	if len(jobs) == 0 {
 		fmt.Println("No resources found.")
 		return


### PR DESCRIPTION
This PR intends to fix an edge case of the `get` subcommand output.

When running on a (Kops) self-hosted cluster, the output of the get command looks like the following:
```bash
NAMESPACE	NODE					NAME							STATUS	AGE
agad-eu		ip-7-0-0-14.eu-east-1.compute.internalkubectl-trace-a3ffa902-ba04-11eb-8e15-acde48001122	Running	7s
agad-eu		ip-7-0-0-14.eu-east-1.compute.internalkubectl-trace-d7f161ea-b9c0-11eb-929a-acde48001122	Failed	8h
```

The following fix produces this output instead:

```bash
NAMESPACE        NODE                                            NAME                                                    STATUS          AGE
agad-eu          ip-7-0-0-14.eu-east-1.compute.internal          kubectl-trace-a3ffa902-ba04-11eb-8e15-acde48001122      Running         7s
agad-eu          ip-7-0-0-14.eu-east-1.compute.internal          kubectl-trace-d7f161ea-b9c0-11eb-929a-acde48001122      Running         8h
```

Thanks for this awesome tool ! 🙂 
