### PR TITLE
feat: upgrade bpftrace to latest version (fixing syntax errors).

### DIFF
--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -1,4 +1,4 @@
-ARG bpftraceversion=v0.11.1
+ARG bpftraceversion=v0.12.1
 FROM quay.io/iovisor/bpftrace:$bpftraceversion as bpftrace
 
 FROM golang:1.15-buster as gobuilder


### PR DESCRIPTION
The current `bpftrace` version doesn't support the syntax of most `*.bt` programs of the bpftrace main repository.

Example of errors :
```bash
$ k logs -f kubectl-trace-efadffc7-28b8-4b22-be68-31e19f712a5d-8kzvv
if your program has maps to print, send a SIGINT using Ctrl-C, if you want to interrupt the execution send SIGINT two times
/programs/program.bt:25:34-37: ERROR: syntax error, unexpected identifier, expecting ) or ","
    printf("%-10u %-5d ", elapsed / 1e6, pid);
                                    ~~~
exit status 1
```

As stated in [this issue](https://github.com/iovisor/bpftrace/issues/1686), upgrading to a more recent version fixes those syntax errors.