### PR TITLE
fix: use goreleaser name template to match krew name format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,10 +41,13 @@ builds:
     binary: trace-runner
 
 archives:
-  - id: windows
+  - id: "kubectl-trace"
+    builds:
+    - "kubectl-trace"
+    name_template: 'kubectl-trace_{{ .Tag }}_{{ .Os }}_{{ .Arch }}'
     format_overrides:
-      - goos: windows
-        format: zip
+    - goos: windows
+      format: zip
 
 snapshot:
   name_template: 'master'


### PR DESCRIPTION
Currently goreleaser omits the "v" from the tag name, which breaks the krew release. This attempts to resolve the issue.