### PR TITLE
feat: Support selecting target process to trace with "process selector"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,13 @@ image/build:
 	$(DOCKER) tag "$(IMAGE_TRACERUNNER_BRANCH)" "$(IMAGE_TRACERUNNER_TAG)"
 	$(DOCKER) tag "$(IMAGE_TRACERUNNER_BRANCH)" "$(IMAGE_TRACERUNNER_LATEST)"
 
+.PHONY: image/integration-support
+image/integration-support: image/ruby-target
+
+.PHONY: image/ruby-target
+image/ruby-target:
+	make -C build/test/ruby image/ruby-target
+
 .PHONY: image/push
 image/push:
 	$(DOCKER) push $(IMAGE_TRACERUNNER_BRANCH)
@@ -118,5 +125,5 @@ test:
 	$(GO) test -v -race $(TESTPACKAGES)
 
 .PHONY: integration
-integration: build image/build image/build-init
+integration: build image/build image/build-init image/integration-support
 	TEST_KUBECTLTRACE_BINARY=$(shell pwd)/$(kubectl_trace) $(GO) test ${LDFLAGS} -failfast -count=1 -v ./integration/... -run TestKubectlTraceSuite $(if $(TEST_ONLY),-testify.m $(TEST_ONLY),)

--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -45,6 +45,7 @@ COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace
 # Inject some fake tracer 'programs' for integration testing.
 COPY /build/test/fake/success /usr/share/fake/success
 COPY /build/test/fake/output /usr/share/fake/output
+COPY /build/test/fake/pidtrace /usr/share/fake/pidtrace
 
 COPY /build/hooks/prestop /bin/hooks/prestop
 

--- a/build/test/fake/pidtrace
+++ b/build/test/fake/pidtrace
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+pid=$1
+
+if [ "$pid" = "" ]; then
+    echo "Usage: pidtrace <PID>"
+    exit 1
+fi
+
+if [ ! -d "/proc/$pid" ]; then
+    echo "PID $pid not found!"
+    exit 1
+fi
+
+echo "Tracing PID $pid..."
+echo
+echo "  nspid: $(cat /proc/$pid/status | awk '/NSpid/ { print $NF }')"
+echo "    exe: $(readlink /proc/$pid/exe)"
+echo "   comm: $(cat /proc/$pid/comm)"
+echo "cmdline: $(cat /proc/$pid/cmdline | tr -d \\0)"
+
+while [[ ! -f "/var/run/trace-uploader" ]]; do
+  sleep 1
+done

--- a/build/test/ruby/Dockerfile
+++ b/build/test/ruby/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.0.1-alpine
+
+COPY fork-from-args ./
+
+CMD ["./fork-from-args"]

--- a/build/test/ruby/Makefile
+++ b/build/test/ruby/Makefile
@@ -1,0 +1,22 @@
+SHELL=/bin/bash -o pipefail
+
+IMAGE_NAME_RUBY ?= quay.io/$(GIT_ORG)/target-ruby
+
+IMAGE_RUBY_BRANCH := $(IMAGE_NAME_RUBY):$(GIT_BRANCH_CLEAN)
+IMAGE_RUBY_COMMIT := $(IMAGE_NAME_RUBY):$(GIT_COMMIT)
+IMAGE_RUBY_TAG    := $(IMAGE_NAME_RUBY):$(GIT_TAG)
+IMAGE_RUBY_LATEST := $(IMAGE_NAME_RUBY):latest
+
+.PHONY: image/ruby-target
+image/ruby-target:
+	DOCKER_BUILDKIT=1 $(DOCKER) build \
+		--build-arg GIT_ORG=$(GIT_ORG) \
+		--progress=$(DOCKER_BUILD_PROGRESS) \
+		-t "$(IMAGE_RUBY_BRANCH)" \
+		-f Dockerfile \
+		${IMAGE_BUILD_FLAGS_EXTRA} \
+		.
+	$(DOCKER) tag "$(IMAGE_RUBY_BRANCH)" $(IMAGE_RUBY_COMMIT)
+	$(DOCKER) tag "$(IMAGE_RUBY_BRANCH)" $(IMAGE_RUBY_BRANCH)
+	$(DOCKER) tag "$(IMAGE_RUBY_BRANCH)" $(IMAGE_RUBY_TAG)
+	$(DOCKER) tag "$(IMAGE_RUBY_BRANCH)" $(IMAGE_RUBY_LATEST)

--- a/build/test/ruby/fork-from-args
+++ b/build/test/ruby/fork-from-args
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+def loop_forever
+  while true
+    puts "#{$0} still alive"
+    sleep(3600)
+  end
+end
+
+trap "SIGINT" do
+  puts "Exiting..."
+  exit
+end
+
+ARGV.each do |arg|
+  fork do
+    $0 = arg
+    loop_forever
+  end
+end
+
+loop_forever

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -45,6 +45,7 @@ type TraceJob struct {
 	ServiceAccount      string
 	Tracer              string
 	Target              TraceJobTarget
+	ProcessSelector     string
 	Output              string
 	Program             string
 	ProgramArgs         []string
@@ -242,6 +243,7 @@ func (nj *TraceJob) Job() *batchv1.Job {
 		"--tracer=" + nj.Tracer,
 		"--pod-uid=" + nj.Target.PodUID,
 		"--container-id=" + nj.Target.ContainerID,
+		"--process-selector=" + nj.ProcessSelector,
 		"--output=" + nj.Output,
 	}
 

--- a/pkg/tracejob/process_selector.go
+++ b/pkg/tracejob/process_selector.go
@@ -1,0 +1,68 @@
+package tracejob
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProcessSelector represents a selector-like label query to select the target process
+// within the container namespace.
+type ProcessSelector struct {
+	// label -> value, values cannot contain spaces.
+	// Assumes equality match, will be changed when more operators added.
+	terms map[string]string
+}
+
+// NewProcessSelector will construct a selector by parsing the query.
+func NewProcessSelector(query string) (*ProcessSelector, error) {
+	s := &ProcessSelector{
+		terms: map[string]string{},
+	}
+
+	query = strings.TrimSpace(query)
+	if len(query) == 0 {
+		return s, nil
+	}
+
+	terms := strings.Split(query, ",")
+	for _, t := range terms {
+		seg := strings.Split(t, "=")
+		if len(seg) != 2 {
+			return nil, fmt.Errorf("invalid term in selector at %s", t)
+		}
+
+		label, value := strings.TrimSpace(seg[0]), strings.TrimSpace(seg[1])
+		s.terms[label] = value
+	}
+
+	return s, nil
+}
+
+func (s *ProcessSelector) String() string {
+	elems := []string{}
+	for k, v := range s.terms {
+		elems = append(elems, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(elems, ",")
+}
+
+func (s *ProcessSelector) Pid() (string, bool) {
+	return s.get("pid")
+}
+
+func (s *ProcessSelector) Exe() (string, bool) {
+	return s.get("exe")
+}
+
+func (s *ProcessSelector) Comm() (string, bool) {
+	return s.get("comm")
+}
+
+func (s *ProcessSelector) Cmdline() (string, bool) {
+	return s.get("cmdline")
+}
+
+func (s *ProcessSelector) get(label string) (string, bool) {
+	value, ok := s.terms[label]
+	return value, ok
+}

--- a/pkg/tracejob/process_selector_test.go
+++ b/pkg/tracejob/process_selector_test.go
@@ -1,0 +1,26 @@
+package tracejob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSelector(t *testing.T) {
+	expected := &ProcessSelector{
+		terms: map[string]string{
+			"pid":  "last",
+			"comm": "foobar",
+		},
+	}
+
+	parsed, _ := NewProcessSelector("comm=foobar, pid=last")
+	assert.Equal(t, expected, parsed)
+}
+
+func TestNewSelectorError(t *testing.T) {
+	_, err := NewProcessSelector("pid=last comm=foobar")
+	assert.NotNil(t, err)
+	_, err = NewProcessSelector("pid=last,, comm=foobar")
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
This adds the ability to target a specific process to trace with the new flag
`--process-selector`. The prior behavior was that only the root PID of a pod
would be traced, which tends to not be the desired target process in most
cases.

Especially with the addition of generic tracers which may only work when a
target pid is provided, the ability to have more fine-grained control over what
process within a pod is targeted is desirable.

The selected process is substituted for `$container_pid` to preserve
backward-compatibility.

The primary author of this functionality was Aaron Olson, but it built on
earlier work from Zeeshan Qureshi who implemented the preliminary selector
work.

Co-authored-by: Aaron Olson <934893+honkfestival@users.noreply.github.com>
Co-authored-by: Zeeshan Qureshi <zee@zqureshi.in>