### PR TITLE
feat: Add rbspy as a supported tracer, support post-processing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Run integration tests
       env: ${{matrix.env}}
       run: |
+        sudo sysctl net/netfilter/nf_conntrack_max=131072 # https://github.com/kubernetes-sigs/kind/issues/2240
         make integration
 
 #    - name: Debug failure over SSH

--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -1,8 +1,10 @@
 # syntax = docker/dockerfile:1.2
 ARG bpftraceversion=v0.13.0
 ARG bccversion=v0.21.0-focal-release
+ARG rbspyversion=0.8.0
 FROM quay.io/iovisor/bpftrace:$bpftraceversion as bpftrace
 FROM quay.io/iovisor/bcc:$bccversion as bcc
+FROM rbspy/rbspy:$rbspyversion-gnu as rbspy
 
 FROM golang:1.15-buster as gobuilder
 ARG GIT_ORG=iovisor
@@ -39,6 +41,7 @@ RUN  apt-get update && \
 RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && apt-get clean
 
 COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace
+COPY --from=rbspy /usr/bin/rbspy /usr/bin/rbspy
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-uploader /bin/trace-uploader
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -189,13 +189,12 @@ func (o *RunOptions) Validate(cmd *cobra.Command, args []string) error {
 	if !o.tracerDefined && cmd.Flag("process-selector").Changed {
 		return fmt.Errorf(tracerNeededForSelectorErrString)
 	}
-
 	if !o.tracerDefined && cmd.Flag("output").Changed {
 		return fmt.Errorf(tracerNeededForOutputErrString)
 	}
 
 	switch o.tracer {
-	case bpftrace, bcc, fake:
+	case bpftrace, bcc, rbspy, fake:
 	default:
 		return fmt.Errorf(tracerNotFound, o.tracer)
 	}
@@ -389,6 +388,10 @@ func validateSelectorForTracer(tracer string, selector *tracejob.ProcessSelector
 	case fake:
 		if _, ok := selector.Pid(); !ok {
 			return fmt.Errorf(pidProcessSelectorRequiredForTracer, fake)
+		}
+	case rbspy:
+		if _, ok := selector.Pid(); !ok {
+			return fmt.Errorf(pidProcessSelectorRequiredForTracer, rbspy)
 		}
 	default:
 	}


### PR DESCRIPTION
This adds rbspy as a supported tracer, the first non-bpf based tracer, for
profiling Ruby processes.

This also adds support for post-processing with tracers, and takes advantage
of this to generate both speedscope and flamegraph output for rbspy.