### PR TITLE
docs: Tracer and secrets docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,39 +339,6 @@ kubectl trace run ip-180-12-0-152.ec2.internal -f read.bt --patch mypatch.json -
 
 Need more programs? Look [here](https://github.com/iovisor/bpftrace/tree/master/tools).
 
-## Status of the project
-
-:trophy: All the MVP goals are done!
-
-To consider this project (ready) the goals are:
-
-- [x] basic program run and attach
-- [x] list command to list running traces - command: `kubectl trace get`
-- [x] delete running traces
-- [x] run without attach
-- [x] attach command to attach only - command: `kubectl trace attach <program>`
-- [x] allow sending signals (probably requires a TTY), so that bpftrace commands can be notified to stop by the user before deletion and give back results
-
-
-**More things after the MVP:**
-
-<i>The stuff here had been implemented - YaY</i>
-
-<strike>The program is now limited to run programs only on your nodes but the idea is to have the ability to attach only to the user namespace of a pod, like:
-
-```
-kubectl trace run pod/<pod-name> -f read.bt
-```
-
-And even on a specific container
-
-```
-kubectl trace run pod/<pod-name> -c <container> f read.bt
-```
-
-So I would say, the next thing is to run bpftrace programs at a pod scope other than at node scope.</strike>
-
-
 ## Contributing
 
 Already pumped up to commit some code? Here are some resources to join the

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ of [bpftrace](https://github.com/iovisor/bpftrace) programs in your Kubernetes c
   * [Executing in a cluster using Pod Security Policies](#executing-in-a-cluster-using-pod-security-policies)
   * [Using a patch to customize the trace job](#using-a-patch-to-customize-the-trace-job)
   * [More bpftrace programs](#more-bpftrace-programs)
-- [Status of the project](#status-of-the-project)
 - [Contributing](#contributing)
 
 <!-- tocstop -->

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,39 @@
+# Using secrets with kubectl-trace
+
+In order to upload traces to blob storage, kubectl-trace will need a way to
+authenticate with a cloud provider. To support this, kubectl-trace offers the
+following flag:
+
+```
+--google-application-secret # for uploading traces to GCS on Google Cloud Platform
+```
+
+With these flags, you can then use a bucket URI pattern for the `--output` flag
+of kubectl-trace.
+
+This allows for centralized storage of traces, and easy integration with third
+party tools for analyzing trace data, in the way that is most appropriate to
+you or your organization.
+
+## Secrets for Google Cloud Storage
+
+To authenticate with Google Cloud Storage, a one-time setup is required where
+secrets must be created ahead of time.
+
+First, create a service account with permissions to upload to a bucket where
+traces shall be stored.
+
+Next, download the service account key for this service account, and create a
+secret in the namespace that traces will be running in:
+
+```
+kubectl create secret generic kubectl-trace-gcp-key --from-file=key.json=PATH-TO-KEY-FILE.json
+```
+
+**Note**: the `key.json` above is critical to ensure the secret is projected correctly
+
+When you create a trace, use the following flags:
+
+```
+--google-application-secret=kubectl-trace-gcp-key
+```

--- a/docs/tracers.md
+++ b/docs/tracers.md
@@ -1,0 +1,16 @@
+# bpftrace
+
+This tracer is the default and is treated special, some of the command line
+options apply only to bpftrace (such as -e).
+
+# Generic tracers
+
+kubectl-trace supports arbitrary tracers, so long as they adhere to the
+existing interface for system (node-level) or process (pod-level) tracing.
+
+If submitting new tracers to the project, they should meet the following
+criteria:
+
+- It should adhere to either the system or process tracing interfaces we already have (or both)
+- It have broad appeal / will it be useful to a wide audience
+- It should not bloat the size of our trace runner image


### PR DESCRIPTION
This adds documentation for generic tracers, including what criteria should be
used for including them in the project.

A missing document for how to work with secrets for uploading to blob storage
is also added.

An obsolete section of the README is also removed.