### PR TITLE
Update init image version and dependencies

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.15
 RUN apk add --update \
     bash \
     bc \
@@ -8,6 +8,10 @@ RUN apk add --update \
     curl \
     elfutils-dev \
     linux-headers \
+	gmp-dev \
+	mpc1-dev \
+	mpfr-dev \
+	python3 \
     make \
     openssl-dev
 

--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -61,6 +61,7 @@ install_cos_linux_headers()
     SOURCES_DIR="${TARGET_DIR}/linux-lakitu-${BUILD_ID}"
 
     if [[ ! -e "${SOURCES_DIR}/.installed" ]]; then
+	mkdir -p ${SOURCES_DIR}
       echo "Installing kernel headers for COS build ${BUILD_ID}"
       time fetch_cos_linux_sources
       time generate_headers
@@ -77,6 +78,7 @@ install_generic_linux_headers()
   SOURCES_DIR="${TARGET_DIR}/linux-generic-${KERNEL_VERSION}"
 
   if [[ ! -e "${SOURCES_DIR}/.installed" ]];then
+	mkdir -p ${SOURCES_DIR}
     echo "Installing kernel headers for generic kernel"
     time fetch_generic_linux_sources
     time generate_headers


### PR DESCRIPTION
This PR updates the Alpine version in the init image to match the trace runner (3.15) to fix an outdated root certificate, adds several dependencies needed for newer kernel builds, and fixes a minor bug in the install script.

Attempting to run with `--fetch-headers` didn't actually fetch headers. Init container logs show:

```
+ curl -sL https://www.kernel.org/pub/linux/kernel/v5.x/linux-5.14.16.tar.gz
+ tar --strip-components=1 -xzf - -C /linux-generic-5.14.16-arch1-1
tar: invalid magic
tar: short read
```

Running the same curl command manually within the container indicated a certificate was expired. Adding OpenSSL clarified that this was due to the old LetsEncrypt [DST root's](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) presence in the chain:

```
/ # openssl s_client -connect www.kernel.org:443
CONNECTED(00000003)
depth=3 O = Digital Signature Trust Co., CN = DST Root CA X3
verify error:num=10:certificate has expired
notAfter=Sep 30 14:01:15 2021 GMT
---
Certificate chain
 0 s:/CN=dfw.source.kernel.org
   i:/C=US/O=Let's Encrypt/CN=R3
 1 s:/C=US/O=Let's Encrypt/CN=R3
   i:/C=US/O=Internet Security Research Group/CN=ISRG Root X1
 2 s:/C=US/O=Internet Security Research Group/CN=ISRG Root X1
   i:/O=Digital Signature Trust Co./CN=DST Root CA X3
```
After bumping the version, I hit several build failures building linux-generic-5.14.16. Adding the additional packages fixed those.

There was a final remaining `touch: /usr/src/linux-generic-5.14.16-arch1-1/.installed: No such file or directory` error in the install script. That may have been benign/ignored (it should have occurred regardless of the kernel version), but I figure it's worth ensuring that directory exists regardless so that the script can run as expected.

Afterwards, `--fetch-headers` created a pod that could run traces successfully.