### PR TITLE
build: Update build and release to produce arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     - windows
     goarch:
     - amd64
+    - arm64
     - 386
     main: ./cmd/kubectl-trace
     env:
@@ -28,6 +29,7 @@ builds:
     - windows
     goarch:
     - amd64
+    - arm64
     - 386
     main: ./cmd/trace-runner
     env:

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -14,6 +14,18 @@ spec:
     bin: kubectl-trace
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-trace
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-trace
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     {{addURIAndSha "https://github.com/iovisor/kubectl-trace/releases/download/{{ .TagName }}/kubectl-trace_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}


### PR DESCRIPTION
Adds new build parameters for the arm64 arch for macOS and linux. Windows may also be addable this way but is not done here.

Fixes #178 