### PR TITLE
Add -S to curl command when fetching generic headers

### DIFF
--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -49,7 +49,7 @@ fetch_generic_linux_sources()
 
   echo "Fetching upstream kernel sources for ${kernel_version}."
   mkdir -p "${BUILD_DIR}"
-  curl -sL "https://www.kernel.org/pub/linux/kernel/v${major_version}.x/linux-$kernel_version.tar.gz" \
+  curl -sSL "https://www.kernel.org/pub/linux/kernel/v${major_version}.x/linux-$kernel_version.tar.gz" \
     | tar --strip-components=1 -xzf - -C "${BUILD_DIR}"
 }
 


### PR DESCRIPTION
`tar` can't seem to read what is being passed to it without this,
see https://github.com/jupyterhub/mybinder.org-deploy/pull/2171#issuecomment-1132838971
for the error message.