### PR TITLE
Add diffutils to the trace initcontainer

### DIFF
--- a/build/Dockerfile.initcontainer
+++ b/build/Dockerfile.initcontainer
@@ -4,6 +4,7 @@ RUN apk add --update \
     bc \
     build-base \
     bison \
+    diffutils \
     flex \
     curl \
     elfutils-dev \

--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -27,7 +27,7 @@ generate_headers()
 }
 
 fetch_cos_linux_sources()
-{S
+{
   echo "Fetching upstream kernel sources."
   mkdir -p "${BUILD_DIR}"
   curl -s "https://storage.googleapis.com/cos-tools/${BUILD_ID}/kernel-src.tar.gz" \

--- a/build/init/fetch-linux-headers.sh
+++ b/build/init/fetch-linux-headers.sh
@@ -27,7 +27,7 @@ generate_headers()
 }
 
 fetch_cos_linux_sources()
-{
+{S
   echo "Fetching upstream kernel sources."
   mkdir -p "${BUILD_DIR}"
   curl -s "https://storage.googleapis.com/cos-tools/${BUILD_ID}/kernel-src.tar.gz" \


### PR DESCRIPTION
Without this, busybox's `diff` is used and I get the following message about 
it not supporting `-I`:

```
+ make ARCH=x86 prepare
diff: unrecognized option: I
BusyBox v1.34.1 (2022-04-04 10:19:27 UTC) multi-call binary.

Usage: diff [-abBdiNqrTstw] [-L LABEL] [-S FILE] [-U LINES] FILE1 FILE2

Compare files line by line and output the differences between them.
This implementation supports unified diffs only.

        -a      Treat all files as text
        -b      Ignore changes in the amount of whitespace
        -B      Ignore changes whose lines are all blank
        -d      Try hard to find a smaller set of changes
        -i      Ignore case differences
        -L      Use LABEL instead of the filename in the unified header
        -N      Treat absent files as empty
        -q      Output only whether files differ
        -r      Recurse
        --no-dereference Don't follow symlinks
        -S      Start with FILE when comparing directories
        -T      Make tabs line up by prefixing a tab when necessary
        -s      Report when two files are the same
        -t      Expand tabs to spaces in output
        -U      Output LINES lines of context
        -w      Ignore all whitespace
Warning: Kernel ABI header at 'tools/arch/x86/include/asm/inat.h' differs from latest version at 'arch/x86/include/asm/inat.h'
diff: unrecognized option: I
BusyBox v1.34.1 (2022-04-04 10:19:27 UTC) multi-call binary.

Usage: diff [-abBdiNqrTstw] [-L LABEL] [-S FILE] [-U LINES] FILE1 FILE2

Compare files line by line and output the differences between them.
This implementation supports unified diffs only.

        -a      Treat all files as text
        -b      Ignore changes in the amount of whitespace
        -B      Ignore changes whose lines are all blank
        -d      Try hard to find a smaller set of changes
        -i      Ignore case differences
        -L      Use LABEL instead of the filename in the unified header
        -N      Treat absent files as empty
        -q      Output only whether files differ
        -r      Recurse
        --no-dereference Don't follow symlinks
        -S      Start with FILE when comparing directories
        -T      Make tabs line up by prefixing a tab when necessary
        -s      Report when two files are the same
        -t      Expand tabs to spaces in output
        -U      Output LINES lines of context
        -w      Ignore all whitespace
Warning: Kernel ABI header at 'tools/arch/x86/include/asm/insn.h' differs from latest version at 'arch/x86/include/asm/insn.h'
diff: unrecognized option: I
BusyBox v1.34.1 (2022-04-04 10:19:27 UTC) multi-call binary.

Usage: diff [-abBdiNqrTstw] [-L LABEL] [-S FILE] [-U LINES] FILE1 FILE2

Compare files line by line and output the differences between them.
This implementation supports unified diffs only.

        -a      Treat all files as text
        -b      Ignore changes in the amount of whitespace
        -B      Ignore changes whose lines are all blank
        -d      Try hard to find a smaller set of changes
        -i      Ignore case differences
        -L      Use LABEL instead of the filename in the unified header
        -N      Treat absent files as empty
        -q      Output only whether files differ
        -r      Recurse
        --no-dereference Don't follow symlinks
        -S      Start with FILE when comparing directories
        -T      Make tabs line up by prefixing a tab when necessary
        -s      Report when two files are the same
        -t      Expand tabs to spaces in output
        -U      Output LINES lines of context
        -w      Ignore all whitespace
Warning: Kernel ABI header at 'tools/arch/x86/lib/inat.c' differs from latest version at 'arch/x86/lib/inat.c'
diff: unrecognized option: I
BusyBox v1.34.1 (2022-04-04 10:19:27 UTC) multi-call binary.

Usage: diff [-abBdiNqrTstw] [-L LABEL] [-S FILE] [-U LINES] FILE1 FILE2

Compare files line by line and output the differences between them.
This implementation supports unified diffs only.

        -a      Treat all files as text
        -b      Ignore changes in the amount of whitespace
        -B      Ignore changes whose lines are all blank
        -d      Try hard to find a smaller set of changes
        -i      Ignore case differences
        -L      Use LABEL instead of the filename in the unified header
        -N      Treat absent files as empty
        -q      Output only whether files differ
        -r      Recurse
        --no-dereference Don't follow symlinks
        -S      Start with FILE when comparing directories
        -T      Make tabs line up by prefixing a tab when necessary
        -s      Report when two files are the same
        -t      Expand tabs to spaces in output
        -U      Output LINES lines of context
        -w      Ignore all whitespace
Warning: Kernel ABI header at 'tools/arch/x86/lib/insn.c' differs from latest version at 'arch/x86/lib/insn.c'
+ find /linux-generic-5.4.144+ -regex '.*\.c\|.*\.txt\|.*Makefile\|.*Build\|.*Kconfig' -type f -delete

real    10m3.441s
user    0m19.081s
sys     0m7.855s
+ rm -rf /usr/src/linux-generic-5.4.144+

real    0m0.001s
user    0m0.001s
sys     0m0.000s
+ mv /linux-generic-5.4.144+ /usr/src

real    0m0.001s
user    0m0.001s
sys     0m0.000s
+ touch /usr/src/linux-generic-5.4.144+/.installed
+ HEADERS_TARGET=/usr/src/linux-generic-5.4.144+
+ mkdir -p /lib/modules/5.4.144+
+ ln -sf /usr/src/linux-generic-5.4.144+ /lib/modules/5.4.144+/source
+ ln -sf /usr/src/linux-generic-5.4.144+ /lib/modules/5.4.144+/build
+ touch /lib/modules/.installed
+ exit 0
```