### PR TITLE
update(.github): build workflow runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04] # 16.04.4 release has 4.15 kernel
-                                         # 18.04.3 release has 5.0.0 kernel
+        os: [ubuntu-18.04, ubuntu-latest]
         env:
         - TEST_KUBERNETES_BACKEND: minikube
         - TEST_KUBERNETES_BACKEND: kind


### PR DESCRIPTION
- ubuntu 16.04 was removed (https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)
- let's test with ubuntu-latest as well
Signed-off-by: Lorenzo Fontana <fontanalorenz@gmail.com>