### PR TITLE
fix(.github): goreleaser links not working

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Build cross binaries
       if: github.ref == 'refs/heads/master'
       run: |
-        curl -LO https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_amd64.deb && sudo dpkg -i goreleaser_amd64.deb
+        go install github.com/goreleaser/goreleaser@latest
         make cross
 
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,10 +18,7 @@ jobs:
         with:
           go-version: 1.15
       - name: Install goreleaser
-        run: |
-          curl -LO https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_amd64.deb && \
-          sudo dpkg -i goreleaser_amd64.deb && \
-          rm goreleaser_amd64.deb
+        run: go install github.com/goreleaser/goreleaser@latest
       - name: Create release
         run: |
           make release


### PR DESCRIPTION
It looks like goreleaser changed the way they distribute packages and that affects our CI.

E.g: https://github.com/iovisor/kubectl-trace/runs/7639883360?check_suite_focus=true