### PR TITLE
feat: make container name be fixed

### DIFF
--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -311,7 +311,7 @@ func (nj *TraceJob) Job() *batchv1.Job {
 					},
 					Containers: []apiv1.Container{
 						apiv1.Container{
-							Name:    nj.Name,
+							Name:    "kubectl-trace",
 							Image:   nj.ImageNameTag,
 							Command: traceCmd,
 							TTY:     true,

--- a/pkg/tracejob/job_test.go
+++ b/pkg/tracejob/job_test.go
@@ -44,7 +44,7 @@ func (j *jobSuite) TestCreateJob() {
 	assert.NotNil(j.T(), joblist)
 
 	assert.Len(j.T(), joblist.Items, 1)
-	assert.Equal(j.T(), joblist.Items[0].Spec.Template.Spec.Containers[0].Name, testJobName)
+	assert.Equal(j.T(), joblist.Items[0].Spec.Template.Spec.Containers[0].Name, "kubectl-trace")
 }
 
 func (j *jobSuite) TestCreateJobWithGoogleAppSecret() {
@@ -64,7 +64,7 @@ func (j *jobSuite) TestCreateJobWithGoogleAppSecret() {
 	assert.NotNil(j.T(), joblist)
 
 	assert.Len(j.T(), joblist.Items, 1)
-	assert.Equal(j.T(), joblist.Items[0].Spec.Template.Spec.Containers[0].Name, testJobName)
+	assert.Equal(j.T(), joblist.Items[0].Spec.Template.Spec.Containers[0].Name, "kubectl-trace")
 
 	assert.Len(j.T(), joblist.Items[0].Spec.Template.Spec.Containers[0].Env, 1)
 	assert.Equal(j.T(), joblist.Items[0].Spec.Template.Spec.Containers[0].Env[0].Name, "GOOGLE_APPLICATION_CREDENTIALS")


### PR DESCRIPTION
- make container name be fixed as 'kubectl-trace'
- added tests to utilize better strategic patch with fixed container name