### PR TITLE
ci: fix goreleaser not being found

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,11 @@ jobs:
           git fetch upstream --tags
         fi
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.19.0'
+
     - name: Run tests
       run: |
         make test

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.15
+          go-version: '>=1.19.0'
       - name: Install goreleaser
         run: go install github.com/goreleaser/goreleaser@latest
       - name: Create release

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ ${trace_uploader}:
 
 .PHONY: cross
 cross:
-	IMAGE_NAME_TRACERUNNER=$(IMAGE_NAME_TRACERUNNER) GO111MODULE=on goreleaser --snapshot --rm-dist
+	IMAGE_NAME_TRACERUNNER=$(IMAGE_NAME_TRACERUNNER) GO111MODULE=on goreleaser --snapshot --clean
 
 .PHONY: release
 release:
-	IMAGE_NAME_TRACERUNNER=$(IMAGE_NAME_TRACERUNNER) GO111MODULE=on goreleaser --rm-dist
+	IMAGE_NAME_TRACERUNNER=$(IMAGE_NAME_TRACERUNNER) GO111MODULE=on goreleaser --clean
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This fixes `goreleaser` not being found during the `make cross` step of the Build and Test workflow, as seen here:

> /bin/bash: goreleaser: command not found

https://github.com/iovisor/kubectl-trace/actions/runs/9952012009/job/27492540456#step:10:283

It would have been sufficient to add $GOPATH/bin to the PATH, but instead I use a `setup-go` step to be consistent with the release workflow, which takes care of this.

Additionally,
- it replaces the [deprecated --rm-dist goreleaser flag](https://goreleaser.com/deprecations/#-rm-dist) with `--clean` which I spotted while testing
- it bumps the go version in the release workflow to at 1.19 or higher in order to follow the `go.mod` file.